### PR TITLE
v0.1.0: foundation + core UI + tagging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.phpunit.cache/    export-ignore
 /setup.sh           export-ignore
 /tests/             export-ignore
+/advanced-revisions-dev/ export-ignore
 /phpcs.xml.dist     export-ignore
 /phpstan.neon.dist  export-ignore
 /phpunit.xml.dist   export-ignore

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,7 +15,7 @@ if ! echo "$STAGED_PHP_FILES" | xargs vendor/bin/phpcs --standard=phpcs.xml.dist
 fi
 
 echo "Running PHPStan..."
-if ! vendor/bin/phpstan analyse --no-progress --memory-limit=512M; then
+if ! vendor/bin/phpstan analyse --no-progress --memory-limit=1G; then
     echo "PHPStan failed. Fix issues before committing."
     exit 1
 fi

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,11 @@
+{
+    "core": null,
+    "plugins": [
+        ".",
+        "./advanced-revisions-dev"
+    ],
+    "config": {
+        "WP_DEBUG": true,
+        "SCRIPT_DEBUG": true
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-04-19
+## [0.1.0] - 2026-04-20
 
 ### Added
 
 - Initial project scaffolding based on `apermo/template-wordpress`
 - PHP 8.1+ codebase with strict types, PSR-4 autoloading under `Apermo\AdvancedRevisions\`
-- Coding standards (`apermo/apermo-coding-standards`) and static analysis (PHPStan with WordPress rules)
+- Coding standards (`apermo/apermo-coding-standards` ^2.9) and static analysis (PHPStan with WordPress rules)
 - PHPUnit test suites (unit + WordPress integration) and Playwright E2E scaffold
 - DDEV local development environment and GitHub Actions CI (lint, analyse, test, WP beta)
 - WordPress.org SVN deploy workflow (disabled until credentials are configured)
@@ -20,19 +20,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-post revision retention override via edit-screen meta box
 - Revision count column + "Manage revisions" row action on post list tables
 - Dashboard widget showing revision stats (total, estimated DB footprint, top posts)
-- Tools → Revisions admin overview + bulk revision deletion
+- Tools → Revisions admin overview + bulk revision deletion with per-parent capability filtering
 - `revision_tag` taxonomy + `protected` term meta flag + `ProtectionService`
+- `advanced_revisions_bulk_delete_capability` filter for overriding the bulk-delete capability
+- Screen-reader labels on the overview's select-all and per-row checkboxes
 - `docs/testing.md` with coverage matrix and fixture scenarios
+
+### Changed
+
+- Overview's required capability raised from `edit_others_posts` to `delete_others_posts` to match the destructive action; filterable via `advanced_revisions_bulk_delete_capability`
+- `RevisionLimitMetaBox::register_post_meta()` runs on `wp_loaded` instead of `init` so CPTs registered at any init priority are picked up
 
 ### Fixed
 
 - PHPStan CI memory limit bumped to 1G (was crashing at 512M)
 - `tests/bootstrap.php` now loads WP class stubs only when no real WP test suite is available (prevents fatal class redeclare in integration runs)
-- `PostListColumn::compare_url()` links to a valid revision ID (was invalid parent ID)
-- `RevisionRepository::revision_ids_for_parents()` now excludes autosaves to match the counts shown in the overview
-- `RevisionLimitMetaBox` uses the `edit_post` meta capability instead of the flat `edit_others_posts` primitive (fixes page/CPT authorization)
+- `PostListColumn::compare_url()` links to a valid revision ID (was invalid parent ID); latest revision IDs now batch-load with the count query, eliminating N+1 `wp_get_post_revisions()` calls on list-table renders
+- `RevisionRepository::revision_ids_for_parents()` excludes autosaves to match the counts shown in the overview
+- `RevisionRepository::total_parents()` joins the parent row and applies the same `post_type`/`post_status` filter as `paginated()` so the paginator denominator matches; orphan revisions and parents in trash/auto-draft no longer inflate the page count
+- `RevisionRepository::paginated()` and `DashboardWidget::compute()` include every non-aggregated column in `GROUP BY` for portability to MySQL configurations with `ONLY_FULL_GROUP_BY` that don't honor functional-dependency detection
+- `DashboardWidget::compute()` excludes autosaves from all three aggregate queries; widget totals now match the overview page and the list-table column
+- `DashboardWidget` split strings rewritten via `_n()` + `wp_kses()` so translators see full sentences with the `<strong>` wrapping as a single translatable unit, and plural forms render correctly
+- `RevisionLimitMetaBox` uses the `edit_post` meta capability with `$post_id` instead of the flat `edit_others_posts` primitive (fixes page/CPT authorization)
+- `RevisionLimitMetaBox` `auth_callback` signature widened to the 6-arg shape WP's `map_meta_cap()` invokes and now honors an earlier filter's strict-`false` denial
+- `OverviewPage::handle_bulk_post()` filters submitted parent IDs through per-parent `current_user_can('edit_post', $id)`, reports unauthorized IDs as `ar_denied`, and terminates with `exit()` after every redirect
 - `OverviewPage::handle_bulk_post()` flushes `DashboardWidget` cache after deletion so stats refresh immediately
-- `ProtectionService` no longer uses O(n) `in_array`; batches term-meta priming and uses O(1) set lookups
+- `ProtectionService` no longer uses O(n) `in_array`; batches revision→term fetches via `wp_get_object_terms()` with `all_with_object_id` and primes termmeta cache with `update_termmeta_cache()` before the per-term lookup
 - `ContentSeeder` / `RevisionSeeder` accept an optional `now` anchor so seeded timestamps are fully deterministic per seed
 
 [0.1.0]: https://github.com/apermo/advanced-revisions/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit test suites (unit + WordPress integration) and Playwright E2E scaffold
 - DDEV local development environment and GitHub Actions CI (lint, analyse, test, WP beta)
 - WordPress.org SVN deploy workflow (disabled until credentials are configured)
+- Sibling `advanced-revisions-dev` plugin with 5 test CPTs + `wp ar-fixtures` WP-CLI seeders
+- Per-post-type revision limit via Settings → Revisions
+- Per-post revision retention override via edit-screen meta box
+- Revision count column + "Manage revisions" row action on post list tables
+- Dashboard widget showing revision stats (total, estimated DB footprint, top posts)
+- Tools → Revisions admin overview + bulk revision deletion
+- `revision_tag` taxonomy + `protected` term meta flag + `ProtectionService`
+- `docs/testing.md` with coverage matrix and fixture scenarios
+
+### Fixed
+
+- PHPStan CI memory limit bumped to 1G (was crashing at 512M)
+- `tests/bootstrap.php` now loads WP class stubs only when no real WP test suite is available (prevents fatal class redeclare in integration runs)
+- `PostListColumn::compare_url()` links to a valid revision ID (was invalid parent ID)
+- `RevisionRepository::revision_ids_for_parents()` now excludes autosaves to match the counts shown in the overview
+- `RevisionLimitMetaBox` uses the `edit_post` meta capability instead of the flat `edit_others_posts` primitive (fixes page/CPT authorization)
+- `OverviewPage::handle_bulk_post()` flushes `DashboardWidget` cache after deletion so stats refresh immediately
+- `ProtectionService` no longer uses O(n) `in_array`; batches term-meta priming and uses O(1) set lookups
+- `ContentSeeder` / `RevisionSeeder` accept an optional `now` anchor so seeded timestamps are fully deterministic per seed
 
 [0.1.0]: https://github.com/apermo/advanced-revisions/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,15 @@ Derived from [`apermo/template-wordpress`](https://github.com/apermo/template-wo
 - Entry class: `src/Plugin.php` (lifecycle: `activate()`, `deactivate()`, `boot()`)
 - Uninstall hook: `uninstall.php`
 
+### Sibling dev plugin
+
+`advanced-revisions-dev/` is a **separate WordPress plugin** that ships test CPTs
+and seed WP-CLI commands. It's excluded from the production ZIP via
+`.gitattributes` `export-ignore`, uses its own inline autoloader (no dependency
+on the main plugin's Composer autoload), and lives under namespace
+`Apermo\AdvancedRevisionsDev\`. Pattern: [inpsyde/WP-Stash](https://github.com/inpsyde/WP-Stash/tree/main/wp-stash-test-plugin).
+Never install it in production.
+
 ### Key conventions
 
 - Coding standards: `apermo/apermo-coding-standards` (PHPCS)

--- a/README.md
+++ b/README.md
@@ -3,18 +3,31 @@
 [![PHP CI](https://github.com/apermo/advanced-revisions/actions/workflows/ci.yml/badge.svg)](https://github.com/apermo/advanced-revisions/actions/workflows/ci.yml)
 [![License: GPL v2+](https://img.shields.io/badge/License-GPLv2+-blue.svg)](LICENSE)
 
-Advanced features for WordPress revisions: configurable limits per post type, an admin overview,
-and bulk deletion tools.
+Advanced features for WordPress revisions: configurable limits per post type, a dashboard widget,
+an admin overview, bulk deletion, and tag-based protection.
 
-> **Status:** v0.1.0 ships project scaffolding only. User-facing features are planned and will be
-> tracked as GitHub issues.
+## Features
 
-## Planned Features
+- **Per-post-type revision limit** — configure via **Settings → Revisions**, overrides `WP_POST_REVISIONS`
+- **Per-post retention override** — meta box on the post edit screen; -1 unlimited, 0 disables for that post
+- **Post list column** — revision count + "Manage revisions" row action linking to the native compare screen
+- **Dashboard widget** — site-wide totals, estimated DB footprint, top-five heaviest posts (cached)
+- **Tools → Revisions overview** — paginated table of posts with stored revisions, heaviest first
+- **Bulk revision deletion** — with per-parent capability filtering and tag-based protection
+- **Revision tagging + protection** — `revision_tag` taxonomy with a `protected` flag that every cleanup path honours
 
-- Configure the number of revisions kept **per post type** (override `WP_POST_REVISIONS`)
-- Admin overview listing revisions across the site
-- Bulk deletion of revisions (by post type, age, or count)
-- Clean, easy-to-use settings UI
+### Capability model
+
+- Overview + bulk delete: `delete_others_posts` by default (filterable via `advanced_revisions_bulk_delete_capability`); per-parent `edit_post` enforced inside the handler
+- Per-post retention override: `edit_post` (`$post_id`)
+
+### Roadmap
+
+- Scheduled/automated cleanup of old revisions (v0.2)
+- Orphan-revision sweep after parent deletion (v0.2)
+- Autosave/revision separation (v0.2)
+- Post-meta revisioning UI (v0.3)
+- WP-CLI commands for listing and cleaning revisions (v0.3)
 
 ## Requirements
 

--- a/advanced-revisions-dev/advanced-revisions-dev.php
+++ b/advanced-revisions-dev/advanced-revisions-dev.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: Advanced Revisions – Dev Fixtures
+ * Description: Test custom post types and seed WP-CLI commands for developing
+ *              Advanced Revisions. DO NOT INSTALL IN PRODUCTION.
+ * Version:     0.1.0
+ * Requires PHP: 8.1
+ * License:     GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev;
+
+\defined( 'ABSPATH' ) || exit();
+
+\spl_autoload_register(
+	// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
+	static function ( string $class_name ): void {
+		$prefix = __NAMESPACE__ . '\\';
+		if ( ! \str_starts_with( $class_name, $prefix ) ) {
+			return;
+		}
+		$relative = \substr( $class_name, \strlen( $prefix ) );
+		$path     = __DIR__ . '/src/' . \str_replace( '\\', '/', $relative ) . '.php';
+		if ( \is_readable( $path ) ) {
+			require $path;
+		}
+	},
+);
+
+add_action( 'init', [ TestPostTypes::class, 'register' ] );

--- a/advanced-revisions-dev/advanced-revisions-dev.php
+++ b/advanced-revisions-dev/advanced-revisions-dev.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Plugin Name: Advanced Revisions – Dev Fixtures
- * Description: Test custom post types and seed WP-CLI commands for developing
- *              Advanced Revisions. DO NOT INSTALL IN PRODUCTION.
- * Version:     0.1.0
+ * Plugin Name:  Advanced Revisions – Dev Fixtures
+ * Description:  Test custom post types and seed WP-CLI commands for developing
+ *               Advanced Revisions. DO NOT INSTALL IN PRODUCTION.
+ * Version:      0.1.0
  * Requires PHP: 8.1
- * License:     GPL-2.0-or-later
+ * License:      GPL-2.0-or-later
  */
 
 declare(strict_types=1);

--- a/advanced-revisions-dev/advanced-revisions-dev.php
+++ b/advanced-revisions-dev/advanced-revisions-dev.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisionsDev;
 
+use WP_CLI;
+
 \defined( 'ABSPATH' ) || exit();
 
 \spl_autoload_register(
@@ -30,3 +32,7 @@ namespace Apermo\AdvancedRevisionsDev;
 );
 
 add_action( 'init', [ TestPostTypes::class, 'register' ] );
+
+if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
+	WP_CLI::add_command( 'ar-fixtures', CLI\FixturesCommand::class );
+}

--- a/advanced-revisions-dev/src/CLI/FixturesCommand.php
+++ b/advanced-revisions-dev/src/CLI/FixturesCommand.php
@@ -12,7 +12,7 @@ use Apermo\AdvancedRevisionsDev\Fixtures\RevisionSeeder;
 use WP_CLI;
 
 /**
- * WP-CLI commands for seeding dev fixtures.
+ * Registers WP-CLI commands for seeding dev fixtures.
  *
  * Registered under `wp ar-fixtures`. Methods map 1:1 to sub-commands.
  */
@@ -195,7 +195,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Convenience: reset revisions then content (reverse of creation order).
+	 * Resets revisions then content (reverse of creation order).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -222,7 +222,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Look up IDs of seeded parent posts matching the configured post types.
+	 * Looks up IDs of seeded parent posts matching the configured post types.
 	 *
 	 * @param array<int, string> $post_types Post type slugs to include.
 	 * @return array<int, int>
@@ -233,7 +233,6 @@ final class FixturesCommand {
 		}
 
 		$ids = get_posts(
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- get_posts args are a WP API shape.
 			[
 				'post_type'      => $post_types,
 				'post_status'    => 'any',
@@ -263,7 +262,11 @@ final class FixturesCommand {
 	 */
 	private function normalize_revisions_options( array $assoc_args ): array {
 		$post_types = ContentSeeder::DEFAULT_POST_TYPES;
-		if ( isset( $assoc_args['post-types'] ) && \is_string( $assoc_args['post-types'] ) && $assoc_args['post-types'] !== '' ) {
+		if (
+			isset( $assoc_args['post-types'] )
+			&& \is_string( $assoc_args['post-types'] )
+			&& $assoc_args['post-types'] !== ''
+		) {
 			$post_types = \array_values(
 				\array_filter(
 					\array_map( 'trim', \explode( ',', $assoc_args['post-types'] ) ),
@@ -272,7 +275,6 @@ final class FixturesCommand {
 			);
 		}
 
-		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- options DTO mirroring CLI flags.
 		return [
 			'distribution'   => (string) ( $assoc_args['distribution'] ?? 'normal' ),
 			'seed'           => (int) ( $assoc_args['seed'] ?? 0 ),
@@ -298,7 +300,11 @@ final class FixturesCommand {
 	 */
 	private function normalize_content_options( array $assoc_args ): array {
 		$post_types = ContentSeeder::DEFAULT_POST_TYPES;
-		if ( isset( $assoc_args['post-types'] ) && \is_string( $assoc_args['post-types'] ) && $assoc_args['post-types'] !== '' ) {
+		if (
+			isset( $assoc_args['post-types'] )
+			&& \is_string( $assoc_args['post-types'] )
+			&& $assoc_args['post-types'] !== ''
+		) {
 			$post_types = \array_values(
 				\array_filter(
 					\array_map( 'trim', \explode( ',', $assoc_args['post-types'] ) ),
@@ -307,7 +313,6 @@ final class FixturesCommand {
 			);
 		}
 
-		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- options shape is an internal DTO mirroring CLI flags.
 		return [
 			'count'       => (int) ( $assoc_args['count'] ?? 50 ),
 			'seed'        => (int) ( $assoc_args['seed'] ?? 0 ),

--- a/advanced-revisions-dev/src/CLI/FixturesCommand.php
+++ b/advanced-revisions-dev/src/CLI/FixturesCommand.php
@@ -6,6 +6,9 @@ namespace Apermo\AdvancedRevisionsDev\CLI;
 
 use Apermo\AdvancedRevisionsDev\Fixtures\ContentGenerator;
 use Apermo\AdvancedRevisionsDev\Fixtures\ContentSeeder;
+use Apermo\AdvancedRevisionsDev\Fixtures\Marker;
+use Apermo\AdvancedRevisionsDev\Fixtures\RevisionGenerator;
+use Apermo\AdvancedRevisionsDev\Fixtures\RevisionSeeder;
 use WP_CLI;
 
 /**
@@ -99,6 +102,185 @@ final class FixturesCommand {
 		$deleted = $seeder->reset();
 
 		WP_CLI::success( \sprintf( 'Deleted %d seeded posts.', $deleted ) );
+	}
+
+	/**
+	 * Seed revisions (and optional autosaves + orphans) on top of seeded posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--distribution=<preset>]
+	 * : How many revisions per post.
+	 * ---
+	 * default: normal
+	 * options:
+	 *   - sparse
+	 *   - normal
+	 *   - heavy
+	 *   - extreme
+	 * ---
+	 *
+	 * [--seed=<seed>]
+	 * : RNG seed for reproducibility.
+	 *
+	 * [--spread-days=<days>]
+	 * : Spread revision post_date values across the last N days.
+	 * ---
+	 * default: 1095
+	 * ---
+	 *
+	 * [--autosave-ratio=<ratio>]
+	 * : Fraction of generated rows that become autosaves instead of revisions.
+	 * ---
+	 * default: 0.1
+	 * ---
+	 *
+	 * [--orphan-count=<count>]
+	 * : Orphan revisions to insert (parent ID is non-existent).
+	 * ---
+	 * default: 20
+	 * ---
+	 *
+	 * [--post-types=<types>]
+	 * : Comma-separated list of post type slugs. Default: all ar_test_* CPTs.
+	 *
+	 * [--append]
+	 * : Keep existing revisions; default is to reset seeded revisions first.
+	 *
+	 * @param array<int, string>   $args       Positional args (unused).
+	 * @param array<string, mixed> $assoc_args Named flags.
+	 */
+	public function revisions( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$options = $this->normalize_revisions_options( $assoc_args );
+		$seeder  = new RevisionSeeder( new RevisionGenerator() );
+		$append  = isset( $assoc_args['append'] ) && (bool) $assoc_args['append'];
+
+		if ( ! $append ) {
+			$seeder->reset();
+		}
+
+		$post_ids = $this->find_seeded_post_ids( $options['post_types'] );
+		$stats    = $seeder->seed( $post_ids, $options );
+
+		WP_CLI::log( \sprintf( 'Seeded %d revisions', $stats['revisions'] ) );
+		WP_CLI::log( \sprintf( 'Seeded %d autosaves', $stats['autosaves'] ) );
+		WP_CLI::log( \sprintf( 'Seeded %d orphan revisions', $stats['orphans'] ) );
+		WP_CLI::success(
+			\sprintf(
+				'Total %d rows inserted.',
+				$stats['revisions'] + $stats['autosaves'] + $stats['orphans'],
+			),
+		);
+	}
+
+	/**
+	 * Delete every revision/autosave/orphan this seeder created.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp ar-fixtures reset-revisions
+	 *
+	 * @param array<int, string>   $args       Positional args (unused).
+	 * @param array<string, mixed> $assoc_args Named flags (unused).
+	 */
+	public function reset_revisions( array $args, array $assoc_args ): void {
+		unset( $args, $assoc_args );
+
+		$seeder  = new RevisionSeeder( new RevisionGenerator() );
+		$deleted = $seeder->reset();
+
+		WP_CLI::success( \sprintf( 'Deleted %d seeded revisions.', $deleted ) );
+	}
+
+	/**
+	 * Convenience: reset revisions then content (reverse of creation order).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp ar-fixtures reset-all
+	 *
+	 * @param array<int, string>   $args       Positional args (unused).
+	 * @param array<string, mixed> $assoc_args Named flags (unused).
+	 */
+	public function reset_all( array $args, array $assoc_args ): void {
+		unset( $args, $assoc_args );
+
+		$rev_seeder      = new RevisionSeeder( new RevisionGenerator() );
+		$content_seeder  = new ContentSeeder( new ContentGenerator() );
+		$deleted_revs    = $rev_seeder->reset();
+		$deleted_content = $content_seeder->reset();
+
+		WP_CLI::success(
+			\sprintf(
+				'Deleted %d seeded revisions and %d seeded posts.',
+				$deleted_revs,
+				$deleted_content,
+			),
+		);
+	}
+
+	/**
+	 * Look up IDs of seeded parent posts matching the configured post types.
+	 *
+	 * @param array<int, string> $post_types Post type slugs to include.
+	 * @return array<int, int>
+	 */
+	private function find_seeded_post_ids( array $post_types ): array {
+		if ( $post_types === [] ) {
+			return [];
+		}
+
+		$ids = get_posts(
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- get_posts args are a WP API shape.
+			[
+				'post_type'      => $post_types,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_key'       => Marker::SEEDED_POST, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => Marker::YES, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'no_found_rows'  => true,
+			],
+		);
+
+		return \array_values( $ids );
+	}
+
+	/**
+	 * Parse + default the revisions command flags.
+	 *
+	 * @param array<string, mixed> $assoc_args Raw flags from WP-CLI.
+	 * @return array{
+	 *     distribution:string,
+	 *     seed:int,
+	 *     spread_days:int,
+	 *     autosave_ratio:float,
+	 *     orphan_count:int,
+	 *     post_types:list<string>
+	 * }
+	 */
+	private function normalize_revisions_options( array $assoc_args ): array {
+		$post_types = ContentSeeder::DEFAULT_POST_TYPES;
+		if ( isset( $assoc_args['post-types'] ) && \is_string( $assoc_args['post-types'] ) && $assoc_args['post-types'] !== '' ) {
+			$post_types = \array_values(
+				\array_filter(
+					\array_map( 'trim', \explode( ',', $assoc_args['post-types'] ) ),
+					static fn( string $slug ): bool => $slug !== '',
+				),
+			);
+		}
+
+		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- options DTO mirroring CLI flags.
+		return [
+			'distribution'   => (string) ( $assoc_args['distribution'] ?? 'normal' ),
+			'seed'           => (int) ( $assoc_args['seed'] ?? 0 ),
+			'spread_days'    => \max( 1, (int) ( $assoc_args['spread-days'] ?? 1095 ) ),
+			'autosave_ratio' => (float) ( $assoc_args['autosave-ratio'] ?? 0.1 ),
+			'orphan_count'   => \max( 0, (int) ( $assoc_args['orphan-count'] ?? 20 ) ),
+			'post_types'     => $post_types,
+		];
 	}
 
 	/**

--- a/advanced-revisions-dev/src/CLI/FixturesCommand.php
+++ b/advanced-revisions-dev/src/CLI/FixturesCommand.php
@@ -19,7 +19,7 @@ use WP_CLI;
 final class FixturesCommand {
 
 	/**
-	 * Seed dummy posts across the configured post types.
+	 * Seeds dummy posts across the configured post types.
 	 *
 	 * ## OPTIONS
 	 *
@@ -86,7 +86,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Delete everything the seeder has created (marker-meta match).
+	 * Deletes everything the seeder has created (marker-meta match).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -105,7 +105,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Seed revisions (and optional autosaves + orphans) on top of seeded posts.
+	 * Seeds revisions (and optional autosaves + orphans) on top of seeded posts.
 	 *
 	 * ## OPTIONS
 	 *
@@ -176,7 +176,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Delete every revision/autosave/orphan this seeder created.
+	 * Deletes every revision/autosave/orphan this seeder created.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -249,7 +249,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Parse + default the revisions command flags.
+	 * Parses + default the revisions command flags.
 	 *
 	 * @param array<string, mixed> $assoc_args Raw flags from WP-CLI.
 	 * @return array{
@@ -284,7 +284,7 @@ final class FixturesCommand {
 	}
 
 	/**
-	 * Parse + defaulted options for the content command.
+	 * Parses + defaulted options for the content command.
 	 *
 	 * @param array<string, mixed> $assoc_args Raw flags from WP-CLI.
 	 * @return array{

--- a/advanced-revisions-dev/src/CLI/FixturesCommand.php
+++ b/advanced-revisions-dev/src/CLI/FixturesCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\CLI;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\ContentGenerator;
+use Apermo\AdvancedRevisionsDev\Fixtures\ContentSeeder;
+use WP_CLI;
+
+/**
+ * WP-CLI commands for seeding dev fixtures.
+ *
+ * Registered under `wp ar-fixtures`. Methods map 1:1 to sub-commands.
+ */
+final class FixturesCommand {
+
+	/**
+	 * Seed dummy posts across the configured post types.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--count=<count>]
+	 * : Posts per post type.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--seed=<seed>]
+	 * : RNG seed for reproducibility. Omit for a random seed.
+	 *
+	 * [--authors=<authors>]
+	 * : Number of test authors to rotate through.
+	 * ---
+	 * default: 3
+	 * ---
+	 *
+	 * [--date-spread=<days>]
+	 * : Spread post_date values across the last N days.
+	 * ---
+	 * default: 1095
+	 * ---
+	 *
+	 * [--status-mix=<preset>]
+	 * : post_status mix.
+	 * ---
+	 * default: publish
+	 * options:
+	 *   - publish
+	 *   - mixed
+	 *   - all
+	 * ---
+	 *
+	 * [--post-types=<types>]
+	 * : Comma-separated list of post type slugs. Default: all ar_test_* CPTs.
+	 *
+	 * [--force]
+	 * : Delete any previously-seeded content before inserting.
+	 *
+	 * @param array<int, string>   $args       Positional args (unused).
+	 * @param array<string, mixed> $assoc_args Named flags.
+	 */
+	public function content( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$options = $this->normalize_content_options( $assoc_args );
+
+		if ( isset( $assoc_args['force'] ) && (bool) $assoc_args['force'] ) {
+			$seeder = new ContentSeeder( new ContentGenerator() );
+			$seeder->reset();
+		}
+
+		$seeder = new ContentSeeder( new ContentGenerator() );
+		$totals = $seeder->seed( $options );
+
+		$grand_total = 0;
+		foreach ( $totals as $post_type => $inserted ) {
+			WP_CLI::log( \sprintf( 'Seeded %d posts into %s', $inserted, $post_type ) );
+			$grand_total += $inserted;
+		}
+
+		WP_CLI::success( \sprintf( 'Seeded %d posts total.', $grand_total ) );
+	}
+
+	/**
+	 * Delete everything the seeder has created (marker-meta match).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp ar-fixtures reset-content
+	 *
+	 * @param array<int, string>   $args       Positional args (unused).
+	 * @param array<string, mixed> $assoc_args Named flags (unused).
+	 */
+	public function reset_content( array $args, array $assoc_args ): void {
+		unset( $args, $assoc_args );
+
+		$seeder  = new ContentSeeder( new ContentGenerator() );
+		$deleted = $seeder->reset();
+
+		WP_CLI::success( \sprintf( 'Deleted %d seeded posts.', $deleted ) );
+	}
+
+	/**
+	 * Parse + defaulted options for the content command.
+	 *
+	 * @param array<string, mixed> $assoc_args Raw flags from WP-CLI.
+	 * @return array{
+	 *     count:int,
+	 *     seed:int,
+	 *     authors:int,
+	 *     date_spread:int,
+	 *     status_mix:string,
+	 *     post_types:list<string>
+	 * }
+	 */
+	private function normalize_content_options( array $assoc_args ): array {
+		$post_types = ContentSeeder::DEFAULT_POST_TYPES;
+		if ( isset( $assoc_args['post-types'] ) && \is_string( $assoc_args['post-types'] ) && $assoc_args['post-types'] !== '' ) {
+			$post_types = \array_values(
+				\array_filter(
+					\array_map( 'trim', \explode( ',', $assoc_args['post-types'] ) ),
+					static fn( string $slug ): bool => $slug !== '',
+				),
+			);
+		}
+
+		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- options shape is an internal DTO mirroring CLI flags.
+		return [
+			'count'       => (int) ( $assoc_args['count'] ?? 50 ),
+			'seed'        => (int) ( $assoc_args['seed'] ?? 0 ),
+			'authors'     => \max( 1, (int) ( $assoc_args['authors'] ?? 3 ) ),
+			'date_spread' => \max( 1, (int) ( $assoc_args['date-spread'] ?? 1095 ) ),
+			'status_mix'  => (string) ( $assoc_args['status-mix'] ?? 'publish' ),
+			'post_types'  => $post_types,
+		];
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisionsDev\Fixtures;
 
-// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- the vocabulary strings below are English content, not SQL.
-
 /**
  * Produces plausible-looking post content arrays deterministically from a
  * Randomizer seed. Output is used by ContentSeeder to feed wp_insert_post().
@@ -53,7 +51,6 @@ final class ContentGenerator {
 	public function post( Randomizer $rng, string $post_type, int $author_id, string $post_status, string $post_date_gmt ): array {
 		$title = $this->title( $rng );
 
-		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
 		return [
 			'post_type'     => $post_type,
 			'post_status'   => $post_status,
@@ -106,7 +103,7 @@ final class ContentGenerator {
 	}
 
 	/**
-	 * Excerpt is the first 160 chars of body, or blank 20% of the time.
+	 * Returns the first 160 chars of body as the excerpt, or blank 20% of the time.
 	 *
 	 * @param Randomizer $rng Deterministic PRNG.
 	 */

--- a/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- the vocabulary strings below are English content, not SQL.
+
+/**
+ * Produces plausible-looking post content arrays deterministically from a
+ * Randomizer seed. Output is used by ContentSeeder to feed wp_insert_post().
+ *
+ * Vocabulary is small on purpose — fixtures need to look distinct, not
+ * Pulitzer-worthy.
+ */
+final class ContentGenerator {
+
+	private const TITLE_TEMPLATES = [
+		'How to %s your %s',
+		'The complete guide to %s',
+		'%s in practice: lessons from a %s team',
+		'Why %s matters for your %s',
+		'%s: a practical review',
+		'Five common %s mistakes (and how to avoid them)',
+		'Before you %s — read this',
+		'Introducing %s for %s',
+	];
+
+	private const VERBS = [ 'configure', 'optimize', 'deploy', 'debug', 'design', 'refactor', 'test', 'document', 'automate', 'ship' ];
+
+	private const NOUNS = [ 'API', 'workflow', 'pipeline', 'architecture', 'deployment', 'review', 'meeting', 'process', 'system', 'dashboard' ];
+
+	private const AUDIENCES = [ 'distributed team', 'growing startup', 'small business', 'enterprise', 'solo developer' ];
+
+	private const BODY_PARAGRAPHS = [
+		'This is fixture content generated for test purposes. It exists to exercise revision comparison and bulk-cleanup flows against realistic-looking post bodies.',
+		'Lorem ipsum would be easier, but having words of varied length in the body makes revision diffs easier to eyeball during manual QA.',
+		'When you see this content, it means the Advanced Revisions dev plugin is active. Deactivate the plugin to hide these posts from the admin.',
+		'Fixture posts carry a marker meta key so the reset-content command can find and delete them without touching any real editorial content.',
+		'Revisions seeded on top of this post will mutate a word or two per save, producing a visible trail in the native revision compare screen.',
+	];
+
+	/**
+	 * Build one post data array (WP_Post shape, ready for wp_insert_post).
+	 *
+	 * @param Randomizer $rng           Deterministic PRNG.
+	 * @param string     $post_type     Target post type slug.
+	 * @param int        $author_id     User ID to assign as post_author.
+	 * @param string     $post_status   post_status value.
+	 * @param string     $post_date_gmt GMT timestamp 'Y-m-d H:i:s'.
+	 * @return array<string, mixed>
+	 */
+	public function post( Randomizer $rng, string $post_type, int $author_id, string $post_status, string $post_date_gmt ): array {
+		$title = $this->title( $rng );
+
+		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
+		return [
+			'post_type'     => $post_type,
+			'post_status'   => $post_status,
+			'post_author'   => $author_id,
+			'post_title'    => $title,
+			'post_content'  => $this->body( $rng ),
+			'post_excerpt'  => $this->excerpt( $rng ),
+			'post_date_gmt' => $post_date_gmt,
+			'post_date'     => $post_date_gmt,
+		];
+	}
+
+	/**
+	 * Generate a plausible post title.
+	 *
+	 * @param Randomizer $rng Deterministic PRNG.
+	 */
+	public function title( Randomizer $rng ): string {
+		$template   = (string) $rng->pick( self::TITLE_TEMPLATES );
+		$slot_count = \substr_count( $template, '%s' );
+		$slots      = [];
+
+		for ( $i = 0; $i < $slot_count; $i++ ) {
+			$slots[] = $this->slot_word( $rng, $i );
+		}
+
+		return \vsprintf( $template, $slots );
+	}
+
+	/**
+	 * Generate a short body composed of 2-4 vocabulary paragraphs.
+	 *
+	 * @param Randomizer $rng Deterministic PRNG.
+	 */
+	public function body( Randomizer $rng ): string {
+		$count      = $rng->int_between( 2, 4 );
+		$indices    = [];
+		$total_pool = \count( self::BODY_PARAGRAPHS );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$indices[] = $rng->int_between( 0, $total_pool - 1 );
+		}
+
+		$paragraphs = [];
+		foreach ( $indices as $index ) {
+			$paragraphs[] = self::BODY_PARAGRAPHS[ $index ];
+		}
+
+		return \implode( "\n\n", $paragraphs );
+	}
+
+	/**
+	 * Excerpt is the first 160 chars of body, or blank 20% of the time.
+	 *
+	 * @param Randomizer $rng Deterministic PRNG.
+	 */
+	public function excerpt( Randomizer $rng ): string {
+		if ( $rng->probability() < 0.2 ) {
+			return '';
+		}
+		return \substr( $this->body( $rng ), 0, 160 );
+	}
+
+	/**
+	 * Pick a vocabulary word appropriate for slot position in a title template.
+	 * Slot 0 tends to be a verb/noun; later slots lean toward nouns/audiences.
+	 *
+	 * @param Randomizer $rng        Deterministic PRNG.
+	 * @param int        $slot_index Zero-based template placeholder index.
+	 */
+	private function slot_word( Randomizer $rng, int $slot_index ): string {
+		if ( $slot_index === 0 ) {
+			$pool = \array_merge( self::VERBS, self::NOUNS );
+		} elseif ( $slot_index === 1 ) {
+			$pool = self::NOUNS;
+		} else {
+			$pool = self::AUDIENCES;
+		}
+
+		return (string) $rng->pick( $pool );
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentGenerator.php
@@ -41,7 +41,7 @@ final class ContentGenerator {
 	];
 
 	/**
-	 * Build one post data array (WP_Post shape, ready for wp_insert_post).
+	 * Builds one post data array (WP_Post shape, ready for wp_insert_post).
 	 *
 	 * @param Randomizer $rng           Deterministic PRNG.
 	 * @param string     $post_type     Target post type slug.
@@ -67,7 +67,7 @@ final class ContentGenerator {
 	}
 
 	/**
-	 * Generate a plausible post title.
+	 * Generates a plausible post title.
 	 *
 	 * @param Randomizer $rng Deterministic PRNG.
 	 */
@@ -84,7 +84,7 @@ final class ContentGenerator {
 	}
 
 	/**
-	 * Generate a short body composed of 2-4 vocabulary paragraphs.
+	 * Generates a short body composed of 2-4 vocabulary paragraphs.
 	 *
 	 * @param Randomizer $rng Deterministic PRNG.
 	 */
@@ -118,7 +118,7 @@ final class ContentGenerator {
 	}
 
 	/**
-	 * Pick a vocabulary word appropriate for slot position in a title template.
+	 * Picks a vocabulary word appropriate for slot position in a title template.
 	 * Slot 0 tends to be a verb/noun; later slots lean toward nouns/audiences.
 	 *
 	 * @param Randomizer $rng        Deterministic PRNG.

--- a/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
@@ -58,8 +58,13 @@ final class ContentSeeder {
 		$rng        = new Randomizer( $options['seed'] );
 		$author_ids = $this->ensure_authors( $options['authors'] );
 		$statuses   = self::STATUS_PRESETS[ $options['status_mix'] ] ?? self::STATUS_PRESETS['publish'];
-		$now_gmt    = \time();
-		$spread     = \max( 1, $options['date_spread'] ) * 86_400;
+		// Anchor "now" to a caller-provided timestamp when given, so --seed=N
+		// produces byte-identical dates across runs. Without an anchor we fall
+		// back to time() — documented as time-relative in that case.
+		$now_gmt = isset( $options['now'] ) && \is_int( $options['now'] ) && $options['now'] > 0
+			? $options['now']
+			: \time();
+		$spread  = \max( 1, $options['date_spread'] ) * 86_400;
 
 		$totals = [];
 		foreach ( $options['post_types'] as $post_type ) {

--- a/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
@@ -39,7 +39,7 @@ final class ContentSeeder {
 	];
 
 	/**
-	 * Inject the shared ContentGenerator.
+	 * Injects the shared ContentGenerator.
 	 *
 	 * @param ContentGenerator $generator Used to produce wp_insert_post shapes.
 	 */
@@ -49,7 +49,7 @@ final class ContentSeeder {
 	}
 
 	/**
-	 * Run a seed pass. Returns a per-post-type count of inserted posts.
+	 * Runs a seed pass. Returns a per-post-type count of inserted posts.
 	 *
 	 * @param array<string, mixed> $options Shape: count:int, seed:int, authors:int, date_spread:int, status_mix:string, post_types:list<string>.
 	 * @return array<string, int>
@@ -92,7 +92,7 @@ final class ContentSeeder {
 	}
 
 	/**
-	 * Delete every post (and its revisions) that was created by the seeder.
+	 * Deletes every post (and its revisions) that was created by the seeder.
 	 *
 	 * @return int Number of parent posts deleted.
 	 */
@@ -127,7 +127,7 @@ final class ContentSeeder {
 	}
 
 	/**
-	 * Ensure N test authors exist. Creates any that are missing.
+	 * Ensures N test authors exist. Creates any that are missing.
 	 *
 	 * @param int $count Number of authors to ensure.
 	 * @return list<int>

--- a/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
@@ -97,7 +97,6 @@ final class ContentSeeder {
 	 */
 	public function reset(): int {
 		$query = new WP_Query(
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- WP_Query args are a WP API shape.
 			[
 				'post_type'      => 'any',
 				'post_status'    => 'any',
@@ -114,7 +113,6 @@ final class ContentSeeder {
 			if ( ! \is_int( $post_id ) ) {
 				continue;
 			}
-			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post() is typed WP_Post|false|null, not WP_Error.
 			$result = wp_delete_post( $post_id, true );
 			if ( $result === false || $result === null ) {
 				continue;
@@ -142,7 +140,6 @@ final class ContentSeeder {
 			}
 
 			$new_id = wp_insert_user(
-				// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_user args are a WP API shape.
 				[
 					'user_login' => $login,
 					'user_email' => Marker::author_email( $i ),

--- a/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+use WP_Query;
+use WP_User;
+
+/**
+ * Inserts seeded content into WordPress. Everything this class creates carries
+ * a marker meta key so {@see self::reset()} can delete exactly what was seeded
+ * without touching real editorial content.
+ */
+final class ContentSeeder {
+
+	/**
+	 * Default target post types when none are specified.
+	 *
+	 * @var list<string>
+	 */
+	public const DEFAULT_POST_TYPES = [
+		'ar_test_article',
+		'ar_test_page',
+		'ar_test_product',
+		'ar_test_note',
+		'ar_test_private',
+	];
+
+	/**
+	 * Allowed post_status values per --status-mix preset.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const STATUS_PRESETS = [
+		'publish' => [ 'publish' ],
+		'mixed'   => [ 'publish', 'draft', 'pending', 'private' ],
+		'all'     => [ 'publish', 'draft', 'pending', 'private', 'future' ],
+	];
+
+	/**
+	 * Inject the shared ContentGenerator.
+	 *
+	 * @param ContentGenerator $generator Used to produce wp_insert_post shapes.
+	 */
+	public function __construct(
+		private readonly ContentGenerator $generator,
+	) {
+	}
+
+	/**
+	 * Run a seed pass. Returns a per-post-type count of inserted posts.
+	 *
+	 * @param array<string, mixed> $options Shape: count:int, seed:int, authors:int, date_spread:int, status_mix:string, post_types:list<string>.
+	 * @return array<string, int>
+	 */
+	public function seed( array $options ): array {
+		$rng        = new Randomizer( $options['seed'] );
+		$author_ids = $this->ensure_authors( $options['authors'] );
+		$statuses   = self::STATUS_PRESETS[ $options['status_mix'] ] ?? self::STATUS_PRESETS['publish'];
+		$now_gmt    = \time();
+		$spread     = \max( 1, $options['date_spread'] ) * 86_400;
+
+		$totals = [];
+		foreach ( $options['post_types'] as $post_type ) {
+			$totals[ $post_type ] = 0;
+			for ( $i = 0; $i < $options['count']; $i++ ) {
+				$author_id = $author_ids[ $rng->int_between( 0, \count( $author_ids ) - 1 ) ];
+				$status    = (string) $rng->pick( $statuses );
+				$offset    = $rng->int_between( 0, $spread );
+				$date_gmt  = \gmdate( 'Y-m-d H:i:s', $now_gmt - $offset );
+
+				$post_data = $this->generator->post( $rng, $post_type, $author_id, $status, $date_gmt );
+				$post_id   = wp_insert_post( $post_data, true );
+
+				// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure; PHPStan's stub narrows too aggressively.
+				if ( is_wp_error( $post_id ) || $post_id <= 0 ) {
+					continue;
+				}
+
+				update_post_meta( $post_id, Marker::SEEDED_POST, Marker::YES );
+				$totals[ $post_type ]++;
+			}
+		}
+
+		return $totals;
+	}
+
+	/**
+	 * Delete every post (and its revisions) that was created by the seeder.
+	 *
+	 * @return int Number of parent posts deleted.
+	 */
+	public function reset(): int {
+		$query = new WP_Query(
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- WP_Query args are a WP API shape.
+			[
+				'post_type'      => 'any',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_key'       => Marker::SEEDED_POST, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => Marker::YES, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'no_found_rows'  => true,
+			],
+		);
+
+		$deleted = 0;
+		foreach ( $query->posts as $post_id ) {
+			if ( ! \is_int( $post_id ) ) {
+				continue;
+			}
+			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post() is typed WP_Post|false|null, not WP_Error.
+			$result = wp_delete_post( $post_id, true );
+			if ( $result === false || $result === null ) {
+				continue;
+			}
+			$deleted++;
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * Ensure N test authors exist. Creates any that are missing.
+	 *
+	 * @param int $count Number of authors to ensure.
+	 * @return list<int>
+	 */
+	private function ensure_authors( int $count ): array {
+		$ids = [];
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$login    = Marker::author_login( $i );
+			$existing = get_user_by( 'login', $login );
+			if ( $existing instanceof WP_User ) {
+				$ids[] = $existing->ID;
+				continue;
+			}
+
+			$new_id = wp_insert_user(
+				// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_user args are a WP API shape.
+				[
+					'user_login' => $login,
+					'user_email' => Marker::author_email( $i ),
+					'user_pass'  => wp_generate_password( 20 ),
+					'role'       => 'editor',
+					'first_name' => 'Test',
+					'last_name'  => 'Author ' . $i,
+				],
+			);
+
+			if ( is_wp_error( $new_id ) || $new_id <= 0 ) {
+				continue;
+			}
+			$ids[] = $new_id;
+		}
+
+		return $ids;
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/ContentSeeder.php
@@ -78,8 +78,7 @@ final class ContentSeeder {
 				$post_data = $this->generator->post( $rng, $post_type, $author_id, $status, $date_gmt );
 				$post_id   = wp_insert_post( $post_data, true );
 
-				// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure; PHPStan's stub narrows too aggressively.
-				if ( is_wp_error( $post_id ) || $post_id <= 0 ) {
+				if ( is_wp_error( $post_id ) ) {
 					continue;
 				}
 
@@ -154,7 +153,7 @@ final class ContentSeeder {
 				],
 			);
 
-			if ( is_wp_error( $new_id ) || $new_id <= 0 ) {
+			if ( is_wp_error( $new_id ) ) {
 				continue;
 			}
 			$ids[] = $new_id;

--- a/advanced-revisions-dev/src/Fixtures/Marker.php
+++ b/advanced-revisions-dev/src/Fixtures/Marker.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisionsDev\Fixtures;
 
 /**
- * Marker meta keys and values used to tag seeded content / revisions so the
- * reset commands can never touch real data.
+ * Centralizes marker meta keys and values used to tag seeded content / revisions
+ * so the reset commands can never touch real data.
  */
 final class Marker {
 

--- a/advanced-revisions-dev/src/Fixtures/Marker.php
+++ b/advanced-revisions-dev/src/Fixtures/Marker.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+/**
+ * Marker meta keys and values used to tag seeded content / revisions so the
+ * reset commands can never touch real data.
+ */
+final class Marker {
+
+	public const SEEDED_POST     = '_ar_seeded';
+	public const SEEDED_REVISION = '_ar_seeded_revision';
+	public const YES             = '1';
+
+	public const AUTHOR_LOGIN_PREFIX = 'ar_test_author_';
+	public const AUTHOR_EMAIL_DOMAIN = 'example.tld';
+
+	/**
+	 * Build the login name for test author N (1-indexed).
+	 *
+	 * @param int $index 1-based author index.
+	 */
+	public static function author_login( int $index ): string {
+		return self::AUTHOR_LOGIN_PREFIX . $index;
+	}
+
+	/**
+	 * Build a deterministic email for test author N.
+	 *
+	 * @param int $index 1-based author index.
+	 */
+	public static function author_email( int $index ): string {
+		return self::author_login( $index ) . '@' . self::AUTHOR_EMAIL_DOMAIN;
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/Marker.php
+++ b/advanced-revisions-dev/src/Fixtures/Marker.php
@@ -18,7 +18,7 @@ final class Marker {
 	public const AUTHOR_EMAIL_DOMAIN = 'example.tld';
 
 	/**
-	 * Build the login name for test author N (1-indexed).
+	 * Builds the login name for test author N (1-indexed).
 	 *
 	 * @param int $index 1-based author index.
 	 */
@@ -27,7 +27,7 @@ final class Marker {
 	}
 
 	/**
-	 * Build a deterministic email for test author N.
+	 * Builds a deterministic email for test author N.
 	 *
 	 * @param int $index 1-based author index.
 	 */

--- a/advanced-revisions-dev/src/Fixtures/Randomizer.php
+++ b/advanced-revisions-dev/src/Fixtures/Randomizer.php
@@ -18,7 +18,7 @@ namespace Apermo\AdvancedRevisionsDev\Fixtures;
 final class Randomizer {
 
 	/**
-	 * Seed the global PRNG.
+	 * Seeds the global PRNG.
 	 *
 	 * @param int $seed Non-zero seed; 0 means "do not seed" (use current global state).
 	 */
@@ -41,7 +41,7 @@ final class Randomizer {
 	}
 
 	/**
-	 * Pick one element from $choices. Returns null for an empty list.
+	 * Picks one element from $choices. Returns null for an empty list.
 	 *
 	 * @param array<int, mixed> $choices Items to pick from.
 	 */

--- a/advanced-revisions-dev/src/Fixtures/Randomizer.php
+++ b/advanced-revisions-dev/src/Fixtures/Randomizer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+/**
+ * Deterministic PRNG wrapper. Seeding the same value reproduces the same
+ * sequence of calls — essential for reproducible fixture scenarios.
+ *
+ * Uses PHP's Mersenne Twister. This touches global state via mt_srand(); the
+ * seeder is single-threaded (WP-CLI), so parallelism is not a concern here.
+ * PHP 8.2's \Random\Randomizer would be cleaner but we target 8.1.
+ *
+ * wp_rand() is the WP-recommended replacement for mt_rand() but it is
+ * deliberately non-deterministic — useless for reproducible fixtures.
+ */
+final class Randomizer {
+
+	/**
+	 * Seed the global PRNG.
+	 *
+	 * @param int $seed Non-zero seed; 0 means "do not seed" (use current global state).
+	 */
+	public function __construct( int $seed = 0 ) {
+		if ( $seed !== 0 ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_mt_srand -- wp_rand() is non-deterministic; fixtures need the seed to carry.
+			\mt_srand( $seed );
+		}
+	}
+
+	/**
+	 * Inclusive random integer in [$min, $max].
+	 *
+	 * @param int $min Lower bound, inclusive.
+	 * @param int $max Upper bound, inclusive.
+	 */
+	public function int_between( int $min, int $max ): int {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand -- wp_rand() is non-deterministic; fixtures need the mt_srand seed to carry.
+		return \mt_rand( $min, $max );
+	}
+
+	/**
+	 * Pick one element from $choices. Returns null for an empty list.
+	 *
+	 * @param array<int, mixed> $choices Items to pick from.
+	 */
+	public function pick( array $choices ): mixed {
+		$count = \count( $choices );
+		if ( $count === 0 ) {
+			return null;
+		}
+		return $choices[ $this->int_between( 0, $count - 1 ) ];
+	}
+
+	/**
+	 * Random float in [0, 1).
+	 */
+	public function probability(): float {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand -- see int_between().
+		return \mt_rand() / ( \mt_getrandmax() + 1 );
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/Randomizer.php
+++ b/advanced-revisions-dev/src/Fixtures/Randomizer.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisionsDev\Fixtures;
 
 /**
- * Deterministic PRNG wrapper. Seeding the same value reproduces the same
- * sequence of calls — essential for reproducible fixture scenarios.
+ * Wraps a deterministic PRNG so the same seed reproduces the same sequence of
+ * calls — essential for reproducible fixture scenarios.
  *
  * Uses PHP's Mersenne Twister. This touches global state via mt_srand(); the
  * seeder is single-threaded (WP-CLI), so parallelism is not a concern here.
@@ -30,7 +30,7 @@ final class Randomizer {
 	}
 
 	/**
-	 * Inclusive random integer in [$min, $max].
+	 * Returns an inclusive random integer in [$min, $max].
 	 *
 	 * @param int $min Lower bound, inclusive.
 	 * @param int $max Upper bound, inclusive.
@@ -54,7 +54,7 @@ final class Randomizer {
 	}
 
 	/**
-	 * Random float in [0, 1).
+	 * Returns a random float in [0, 1).
 	 */
 	public function probability(): float {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand -- see int_between().

--- a/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
@@ -27,7 +27,7 @@ final class RevisionGenerator {
 	];
 
 	/**
-	 * Append a short mutation marker to the body.
+	 * Appends a short mutation marker to the body.
 	 *
 	 * @param Randomizer $rng      Deterministic PRNG.
 	 * @param string     $original Existing post body.
@@ -41,7 +41,7 @@ final class RevisionGenerator {
 	}
 
 	/**
-	 * Mutate a title with a small suffix. Most revisions keep the same title;
+	 * Mutates a title with a small suffix. Most revisions keep the same title;
 	 * ~10% of the time we tweak it so the diff covers title changes too.
 	 *
 	 * @param Randomizer $rng      Deterministic PRNG.

--- a/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- vocabulary strings below are English, not SQL.
+
+/**
+ * Mutates post bodies to produce visible diffs between revisions.
+ *
+ * The goal is that a human browsing the native revision.php compare screen
+ * sees a meaningful diff between any two adjacent revisions — not identical
+ * text. Mutations are small and deterministic given a seeded Randomizer.
+ */
+final class RevisionGenerator {
+
+	private const EDIT_TOKENS = [
+		'updated',
+		'revised',
+		'clarified',
+		'expanded',
+		'refactored',
+		'rephrased',
+		'trimmed',
+		'polished',
+	];
+
+	/**
+	 * Append a short mutation marker to the body.
+	 *
+	 * @param Randomizer $rng      Deterministic PRNG.
+	 * @param string     $original Existing post body.
+	 * @param int        $revision_index 1-based revision number for this post.
+	 */
+	public function mutated_body( Randomizer $rng, string $original, int $revision_index ): string {
+		$token = (string) $rng->pick( self::EDIT_TOKENS );
+		$nonce = $rng->int_between( 1000, 9_999 );
+
+		return $original . "\n\n[rev {$revision_index}] " . $token . ' (' . $nonce . ')';
+	}
+
+	/**
+	 * Mutate a title with a small suffix. Most revisions keep the same title;
+	 * ~10% of the time we tweak it so the diff covers title changes too.
+	 *
+	 * @param Randomizer $rng      Deterministic PRNG.
+	 * @param string     $original Current post title.
+	 */
+	public function mutated_title( Randomizer $rng, string $original ): string {
+		if ( $rng->probability() < 0.9 ) {
+			return $original;
+		}
+		$suffix = (string) $rng->pick( self::EDIT_TOKENS );
+		return $original . ' — ' . $suffix;
+	}
+}

--- a/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionGenerator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisionsDev\Fixtures;
 
-// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- vocabulary strings below are English, not SQL.
-
 /**
  * Mutates post bodies to produce visible diffs between revisions.
  *

--- a/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
@@ -207,8 +207,7 @@ final class RevisionSeeder {
 			true,
 		);
 
-		// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure.
-		if ( is_wp_error( $row_id ) || $row_id <= 0 ) {
+		if ( is_wp_error( $row_id ) ) {
 			return false;
 		}
 
@@ -243,8 +242,7 @@ final class RevisionSeeder {
 			true,
 		);
 
-		// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure.
-		if ( is_wp_error( $row_id ) || $row_id <= 0 ) {
+		if ( is_wp_error( $row_id ) ) {
 			return false;
 		}
 

--- a/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
@@ -31,7 +31,7 @@ final class RevisionSeeder {
 	];
 
 	/**
-	 * Inject the shared RevisionGenerator.
+	 * Injects the shared RevisionGenerator.
 	 *
 	 * @param RevisionGenerator $generator Used to mutate post bodies/titles.
 	 */
@@ -41,7 +41,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Run a revision-seed pass. Returns a stats map.
+	 * Runs a revision-seed pass. Returns a stats map.
 	 *
 	 * @param array<int, int>      $post_ids IDs of parent posts to revision.
 	 * @param array<string, mixed> $options  Shape: distribution:string, seed:int, spread_days:int, autosave_ratio:float, orphan_count:int.
@@ -76,7 +76,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Seed revisions + autosaves for one parent post.
+	 * Seeds revisions + autosaves for one parent post.
 	 *
 	 * @param Randomizer     $rng         Deterministic PRNG.
 	 * @param int            $post_id     Parent post ID.
@@ -103,7 +103,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Insert N revisions of a given variant and report how many succeeded.
+	 * Inserts N revisions of a given variant and report how many succeeded.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param WP_Post    $parent_post Parent post.
@@ -123,7 +123,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Insert N orphan revisions.
+	 * Inserts N orphan revisions.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $count       Number of orphans to insert.
@@ -141,7 +141,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Delete every revision this seeder created (marker-meta match).
+	 * Deletes every revision this seeder created (marker-meta match).
 	 *
 	 * @return int Number of revisions deleted.
 	 */
@@ -176,7 +176,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Insert one revision row (or autosave) for a given parent post.
+	 * Inserts one revision row (or autosave) for a given parent post.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param WP_Post    $parent_post Parent post.
@@ -217,7 +217,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Insert an orphan revision — post_parent points to a non-existent ID.
+	 * Inserts an orphan revision — post_parent points to a non-existent ID.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $spread_days Historical date window in days.
@@ -253,7 +253,7 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Pick a GMT timestamp within the last $spread_days days, anchored on $now_gmt.
+	 * Picks a GMT timestamp within the last $spread_days days, anchored on $now_gmt.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $spread_days Window size in days.

--- a/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
@@ -54,6 +54,10 @@ final class RevisionSeeder {
 		$ratio   = (float) ( $options['autosave_ratio'] ?? 0.1 );
 		$orphans = \max( 0, (int) ( $options['orphan_count'] ?? 0 ) );
 		$range   = self::DISTRIBUTIONS[ $dist ] ?? self::DISTRIBUTIONS['normal'];
+		// Anchor "now" once per run so --seed=N reproduces identical timestamps.
+		$now_gmt = isset( $options['now'] ) && \is_int( $options['now'] ) && $options['now'] > 0
+			? $options['now']
+			: \time();
 		$stats   = [
 			'revisions' => 0,
 			'autosaves' => 0,
@@ -61,12 +65,12 @@ final class RevisionSeeder {
 		];
 
 		foreach ( $post_ids as $post_id ) {
-			$counts = $this->seed_for_parent( $rng, $post_id, $range, $ratio, $spread );
+			$counts = $this->seed_for_parent( $rng, $post_id, $range, $ratio, $spread, $now_gmt );
 			$stats['revisions'] += $counts[0];
 			$stats['autosaves'] += $counts[1];
 		}
 
-		$stats['orphans'] = $this->seed_orphans( $rng, $orphans, $spread );
+		$stats['orphans'] = $this->seed_orphans( $rng, $orphans, $spread, $now_gmt );
 
 		return $stats;
 	}
@@ -76,12 +80,13 @@ final class RevisionSeeder {
 	 *
 	 * @param Randomizer     $rng         Deterministic PRNG.
 	 * @param int            $post_id     Parent post ID.
-	 * @param array{int,int} $range     [min, max] revision count bounds.
+	 * @param array{int,int} $range       [min, max] revision count bounds.
 	 * @param float          $ratio       Autosave ratio (0..1).
 	 * @param int            $spread_days Historical date window in days.
+	 * @param int            $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 * @return array{int, int} Tuple of [revisions_inserted, autosaves_inserted].
 	 */
-	private function seed_for_parent( Randomizer $rng, int $post_id, array $range, float $ratio, int $spread_days ): array {
+	private function seed_for_parent( Randomizer $rng, int $post_id, array $range, float $ratio, int $spread_days, int $now_gmt ): array {
 		$parent_post = get_post( $post_id );
 		if ( ! $parent_post instanceof WP_Post ) {
 			return [ 0, 0 ];
@@ -91,8 +96,8 @@ final class RevisionSeeder {
 		$autosave_count = (int) \floor( $total * $ratio );
 		$revision_count = $total - $autosave_count;
 
-		$revisions = $this->insert_revisions( $rng, $parent_post, $revision_count, $spread_days, false );
-		$autosaves = $this->insert_revisions( $rng, $parent_post, $autosave_count, $spread_days, true );
+		$revisions = $this->insert_revisions( $rng, $parent_post, $revision_count, $spread_days, false, $now_gmt );
+		$autosaves = $this->insert_revisions( $rng, $parent_post, $autosave_count, $spread_days, true, $now_gmt );
 
 		return [ $revisions, $autosaves ];
 	}
@@ -105,11 +110,12 @@ final class RevisionSeeder {
 	 * @param int        $count       Number of rows to insert.
 	 * @param int        $spread_days Historical date window in days.
 	 * @param bool       $is_autosave Whether to use the autosave post_name pattern.
+	 * @param int        $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 */
-	private function insert_revisions( Randomizer $rng, WP_Post $parent_post, int $count, int $spread_days, bool $is_autosave ): int {
+	private function insert_revisions( Randomizer $rng, WP_Post $parent_post, int $count, int $spread_days, bool $is_autosave, int $now_gmt ): int {
 		$inserted = 0;
 		for ( $i = 1; $i <= $count; $i++ ) {
-			if ( $this->insert_revision( $rng, $parent_post, $i, $spread_days, $is_autosave ) ) {
+			if ( $this->insert_revision( $rng, $parent_post, $i, $spread_days, $is_autosave, $now_gmt ) ) {
 				$inserted++;
 			}
 		}
@@ -122,11 +128,12 @@ final class RevisionSeeder {
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $count       Number of orphans to insert.
 	 * @param int        $spread_days Historical date window in days.
+	 * @param int        $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 */
-	private function seed_orphans( Randomizer $rng, int $count, int $spread_days ): int {
+	private function seed_orphans( Randomizer $rng, int $count, int $spread_days, int $now_gmt ): int {
 		$inserted = 0;
 		for ( $i = 0; $i < $count; $i++ ) {
-			if ( $this->insert_orphan( $rng, $spread_days, $i ) ) {
+			if ( $this->insert_orphan( $rng, $spread_days, $i, $now_gmt ) ) {
 				$inserted++;
 			}
 		}
@@ -171,16 +178,17 @@ final class RevisionSeeder {
 	/**
 	 * Insert one revision row (or autosave) for a given parent post.
 	 *
-	 * @param Randomizer $rng              Deterministic PRNG.
-	 * @param WP_Post    $parent_post           Parent post.
-	 * @param int        $index            1-based revision index for this parent.
-	 * @param int        $spread_days      Historical date window in days.
-	 * @param bool       $is_autosave      Whether to use the autosave post_name pattern.
+	 * @param Randomizer $rng         Deterministic PRNG.
+	 * @param WP_Post    $parent_post Parent post.
+	 * @param int        $index       1-based revision index for this parent.
+	 * @param int        $spread_days Historical date window in days.
+	 * @param bool       $is_autosave Whether to use the autosave post_name pattern.
+	 * @param int        $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 */
-	private function insert_revision( Randomizer $rng, WP_Post $parent_post, int $index, int $spread_days, bool $is_autosave ): bool {
+	private function insert_revision( Randomizer $rng, WP_Post $parent_post, int $index, int $spread_days, bool $is_autosave, int $now_gmt ): bool {
 		$mutation = $this->generator->mutated_body( $rng, $parent_post->post_content, $index );
 		$title    = $this->generator->mutated_title( $rng, $parent_post->post_title );
-		$date_gmt = $this->historical_date( $rng, $spread_days );
+		$date_gmt = $this->historical_date( $rng, $spread_days, $now_gmt );
 		$suffix   = $is_autosave ? '-autosave-v' : '-revision-v';
 
 		$row_id = wp_insert_post(
@@ -214,10 +222,11 @@ final class RevisionSeeder {
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $spread_days Historical date window in days.
 	 * @param int        $index       0-based orphan index, used to vary post_name.
+	 * @param int        $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 */
-	private function insert_orphan( Randomizer $rng, int $spread_days, int $index ): bool {
+	private function insert_orphan( Randomizer $rng, int $spread_days, int $index, int $now_gmt ): bool {
 		$fake_parent_id = 999_000_000 + $index;
-		$date_gmt       = $this->historical_date( $rng, $spread_days );
+		$date_gmt       = $this->historical_date( $rng, $spread_days, $now_gmt );
 
 		$row_id = wp_insert_post(
 			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
@@ -244,13 +253,14 @@ final class RevisionSeeder {
 	}
 
 	/**
-	 * Pick a GMT timestamp within the last $spread_days days.
+	 * Pick a GMT timestamp within the last $spread_days days, anchored on $now_gmt.
 	 *
 	 * @param Randomizer $rng         Deterministic PRNG.
 	 * @param int        $spread_days Window size in days.
+	 * @param int        $now_gmt     Anchor timestamp (seconds since epoch, UTC).
 	 */
-	private function historical_date( Randomizer $rng, int $spread_days ): string {
+	private function historical_date( Randomizer $rng, int $spread_days, int $now_gmt ): string {
 		$offset = $rng->int_between( 0, $spread_days * 86_400 );
-		return \gmdate( 'Y-m-d H:i:s', \time() - $offset );
+		return \gmdate( 'Y-m-d H:i:s', $now_gmt - $offset );
 	}
 }

--- a/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
@@ -147,7 +147,6 @@ final class RevisionSeeder {
 	 */
 	public function reset(): int {
 		$query = new WP_Query(
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- WP_Query args are a WP API shape.
 			[
 				'post_type'      => [ 'revision' ],
 				'post_status'    => 'inherit',
@@ -164,7 +163,6 @@ final class RevisionSeeder {
 			if ( ! \is_int( $revision_id ) ) {
 				continue;
 			}
-			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post_revision typed without WP_Error.
 			$result = wp_delete_post_revision( $revision_id );
 			if ( $result === false || $result === null ) {
 				continue;
@@ -192,7 +190,6 @@ final class RevisionSeeder {
 		$suffix   = $is_autosave ? '-autosave-v' : '-revision-v';
 
 		$row_id = wp_insert_post(
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
 			[
 				'post_type'     => 'revision',
 				'post_parent'   => $parent_post->ID,
@@ -228,7 +225,6 @@ final class RevisionSeeder {
 		$date_gmt       = $this->historical_date( $rng, $spread_days, $now_gmt );
 
 		$row_id = wp_insert_post(
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
 			[
 				'post_type'     => 'revision',
 				'post_parent'   => $fake_parent_id,

--- a/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
+++ b/advanced-revisions-dev/src/Fixtures/RevisionSeeder.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Fixtures;
+
+use WP_Post;
+use WP_Query;
+
+/**
+ * Creates revision rows (and optional autosaves + orphans) on top of seeded
+ * content. Every row created here carries {@see Marker::SEEDED_REVISION} so
+ * {@see self::reset()} can delete exactly what was seeded.
+ *
+ * Revisions are inserted via wp_insert_post() with post_type='revision'; this
+ * is what core does internally. Autosaves share the same shape with a
+ * different post_name suffix.
+ */
+final class RevisionSeeder {
+
+	/**
+	 * Revision counts per distribution preset: [min, max].
+	 *
+	 * @var array<string, array{int, int}>
+	 */
+	private const DISTRIBUTIONS = [
+		'sparse'  => [ 0, 5 ],
+		'normal'  => [ 1, 25 ],
+		'heavy'   => [ 10, 100 ],
+		'extreme' => [ 100, 500 ],
+	];
+
+	/**
+	 * Inject the shared RevisionGenerator.
+	 *
+	 * @param RevisionGenerator $generator Used to mutate post bodies/titles.
+	 */
+	public function __construct(
+		private readonly RevisionGenerator $generator,
+	) {
+	}
+
+	/**
+	 * Run a revision-seed pass. Returns a stats map.
+	 *
+	 * @param array<int, int>      $post_ids IDs of parent posts to revision.
+	 * @param array<string, mixed> $options  Shape: distribution:string, seed:int, spread_days:int, autosave_ratio:float, orphan_count:int.
+	 * @return array{revisions:int, autosaves:int, orphans:int}
+	 */
+	public function seed( array $post_ids, array $options ): array {
+		$rng     = new Randomizer( (int) ( $options['seed'] ?? 0 ) );
+		$dist    = (string) ( $options['distribution'] ?? 'normal' );
+		$spread  = \max( 1, (int) ( $options['spread_days'] ?? 1095 ) );
+		$ratio   = (float) ( $options['autosave_ratio'] ?? 0.1 );
+		$orphans = \max( 0, (int) ( $options['orphan_count'] ?? 0 ) );
+		$range   = self::DISTRIBUTIONS[ $dist ] ?? self::DISTRIBUTIONS['normal'];
+		$stats   = [
+			'revisions' => 0,
+			'autosaves' => 0,
+			'orphans'   => 0,
+		];
+
+		foreach ( $post_ids as $post_id ) {
+			$counts = $this->seed_for_parent( $rng, $post_id, $range, $ratio, $spread );
+			$stats['revisions'] += $counts[0];
+			$stats['autosaves'] += $counts[1];
+		}
+
+		$stats['orphans'] = $this->seed_orphans( $rng, $orphans, $spread );
+
+		return $stats;
+	}
+
+	/**
+	 * Seed revisions + autosaves for one parent post.
+	 *
+	 * @param Randomizer     $rng         Deterministic PRNG.
+	 * @param int            $post_id     Parent post ID.
+	 * @param array{int,int} $range     [min, max] revision count bounds.
+	 * @param float          $ratio       Autosave ratio (0..1).
+	 * @param int            $spread_days Historical date window in days.
+	 * @return array{int, int} Tuple of [revisions_inserted, autosaves_inserted].
+	 */
+	private function seed_for_parent( Randomizer $rng, int $post_id, array $range, float $ratio, int $spread_days ): array {
+		$parent_post = get_post( $post_id );
+		if ( ! $parent_post instanceof WP_Post ) {
+			return [ 0, 0 ];
+		}
+
+		$total          = $rng->int_between( $range[0], $range[1] );
+		$autosave_count = (int) \floor( $total * $ratio );
+		$revision_count = $total - $autosave_count;
+
+		$revisions = $this->insert_revisions( $rng, $parent_post, $revision_count, $spread_days, false );
+		$autosaves = $this->insert_revisions( $rng, $parent_post, $autosave_count, $spread_days, true );
+
+		return [ $revisions, $autosaves ];
+	}
+
+	/**
+	 * Insert N revisions of a given variant and report how many succeeded.
+	 *
+	 * @param Randomizer $rng         Deterministic PRNG.
+	 * @param WP_Post    $parent_post Parent post.
+	 * @param int        $count       Number of rows to insert.
+	 * @param int        $spread_days Historical date window in days.
+	 * @param bool       $is_autosave Whether to use the autosave post_name pattern.
+	 */
+	private function insert_revisions( Randomizer $rng, WP_Post $parent_post, int $count, int $spread_days, bool $is_autosave ): int {
+		$inserted = 0;
+		for ( $i = 1; $i <= $count; $i++ ) {
+			if ( $this->insert_revision( $rng, $parent_post, $i, $spread_days, $is_autosave ) ) {
+				$inserted++;
+			}
+		}
+		return $inserted;
+	}
+
+	/**
+	 * Insert N orphan revisions.
+	 *
+	 * @param Randomizer $rng         Deterministic PRNG.
+	 * @param int        $count       Number of orphans to insert.
+	 * @param int        $spread_days Historical date window in days.
+	 */
+	private function seed_orphans( Randomizer $rng, int $count, int $spread_days ): int {
+		$inserted = 0;
+		for ( $i = 0; $i < $count; $i++ ) {
+			if ( $this->insert_orphan( $rng, $spread_days, $i ) ) {
+				$inserted++;
+			}
+		}
+		return $inserted;
+	}
+
+	/**
+	 * Delete every revision this seeder created (marker-meta match).
+	 *
+	 * @return int Number of revisions deleted.
+	 */
+	public function reset(): int {
+		$query = new WP_Query(
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- WP_Query args are a WP API shape.
+			[
+				'post_type'      => [ 'revision' ],
+				'post_status'    => 'inherit',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_key'       => Marker::SEEDED_REVISION, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => Marker::YES, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'no_found_rows'  => true,
+			],
+		);
+
+		$deleted = 0;
+		foreach ( $query->posts as $revision_id ) {
+			if ( ! \is_int( $revision_id ) ) {
+				continue;
+			}
+			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post_revision typed without WP_Error.
+			$result = wp_delete_post_revision( $revision_id );
+			if ( $result === false || $result === null ) {
+				continue;
+			}
+			$deleted++;
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * Insert one revision row (or autosave) for a given parent post.
+	 *
+	 * @param Randomizer $rng              Deterministic PRNG.
+	 * @param WP_Post    $parent_post           Parent post.
+	 * @param int        $index            1-based revision index for this parent.
+	 * @param int        $spread_days      Historical date window in days.
+	 * @param bool       $is_autosave      Whether to use the autosave post_name pattern.
+	 */
+	private function insert_revision( Randomizer $rng, WP_Post $parent_post, int $index, int $spread_days, bool $is_autosave ): bool {
+		$mutation = $this->generator->mutated_body( $rng, $parent_post->post_content, $index );
+		$title    = $this->generator->mutated_title( $rng, $parent_post->post_title );
+		$date_gmt = $this->historical_date( $rng, $spread_days );
+		$suffix   = $is_autosave ? '-autosave-v' : '-revision-v';
+
+		$row_id = wp_insert_post(
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
+			[
+				'post_type'     => 'revision',
+				'post_parent'   => $parent_post->ID,
+				'post_status'   => 'inherit',
+				'post_name'     => $parent_post->ID . $suffix . $index,
+				'post_title'    => $title,
+				'post_content'  => $mutation,
+				'post_author'   => (int) $parent_post->post_author,
+				'post_date_gmt' => $date_gmt,
+				'post_date'     => $date_gmt,
+			],
+			true,
+		);
+
+		// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure.
+		if ( is_wp_error( $row_id ) || $row_id <= 0 ) {
+			return false;
+		}
+
+		update_post_meta( $row_id, Marker::SEEDED_REVISION, Marker::YES );
+		return true;
+	}
+
+	/**
+	 * Insert an orphan revision — post_parent points to a non-existent ID.
+	 *
+	 * @param Randomizer $rng         Deterministic PRNG.
+	 * @param int        $spread_days Historical date window in days.
+	 * @param int        $index       0-based orphan index, used to vary post_name.
+	 */
+	private function insert_orphan( Randomizer $rng, int $spread_days, int $index ): bool {
+		$fake_parent_id = 999_000_000 + $index;
+		$date_gmt       = $this->historical_date( $rng, $spread_days );
+
+		$row_id = wp_insert_post(
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- wp_insert_post args are a WP API shape.
+			[
+				'post_type'     => 'revision',
+				'post_parent'   => $fake_parent_id,
+				'post_status'   => 'inherit',
+				'post_name'     => $fake_parent_id . '-revision-v1',
+				'post_title'    => 'Orphan fixture',
+				'post_content'  => $this->generator->mutated_body( $rng, 'Orphaned parent was hard-deleted.', 1 ),
+				'post_date_gmt' => $date_gmt,
+				'post_date'     => $date_gmt,
+			],
+			true,
+		);
+
+		// @phpstan-ignore-next-line smaller.alwaysFalse -- wp_insert_post can return 0 on silent failure.
+		if ( is_wp_error( $row_id ) || $row_id <= 0 ) {
+			return false;
+		}
+
+		update_post_meta( $row_id, Marker::SEEDED_REVISION, Marker::YES );
+		return true;
+	}
+
+	/**
+	 * Pick a GMT timestamp within the last $spread_days days.
+	 *
+	 * @param Randomizer $rng         Deterministic PRNG.
+	 * @param int        $spread_days Window size in days.
+	 */
+	private function historical_date( Randomizer $rng, int $spread_days ): string {
+		$offset = $rng->int_between( 0, $spread_days * 86_400 );
+		return \gmdate( 'Y-m-d H:i:s', \time() - $offset );
+	}
+}

--- a/advanced-revisions-dev/src/TestPostTypes.php
+++ b/advanced-revisions-dev/src/TestPostTypes.php
@@ -31,7 +31,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Post type definitions keyed by slug.
+	 * Returns post type definitions keyed by slug.
 	 *
 	 * @return array<string, array<string, mixed>>
 	 */
@@ -46,7 +46,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Flat public post type with full revision support.
+	 * Defines a flat public post type with full revision support.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -58,7 +58,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Hierarchical public post type — exercises parent/child admin UX.
+	 * Defines a hierarchical public post type that exercises parent/child admin UX.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -70,7 +70,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Post type with revisioned custom meta for exercising meta-revisioning (#9).
+	 * Defines a post type with revisioned custom meta for exercising meta-revisioning (#9).
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -82,7 +82,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Post type with revisions explicitly disabled — negative coverage.
+	 * Defines a post type with revisions explicitly disabled — negative coverage.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -94,7 +94,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Non-public post type — exercises capability gating.
+	 * Defines a non-public post type that exercises capability gating.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -107,7 +107,7 @@ final class TestPostTypes {
 	}
 
 	/**
-	 * Shared defaults applied to every test post type.
+	 * Returns shared defaults applied to every test post type.
 	 *
 	 * @param string $name            Plural label.
 	 * @param string $singular        Singular label.
@@ -116,7 +116,6 @@ final class TestPostTypes {
 	 * @return array<string, mixed>
 	 */
 	private static function base( string $name, string $singular, string $capability_type, bool $is_public = true ): array {
-		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- register_post_type args are a WP API shape, not a candidate for a typed object.
 		return [
 			'labels'          => [
 				'name'          => $name,

--- a/advanced-revisions-dev/src/TestPostTypes.php
+++ b/advanced-revisions-dev/src/TestPostTypes.php
@@ -12,7 +12,7 @@ namespace Apermo\AdvancedRevisionsDev;
 final class TestPostTypes {
 
 	/**
-	 * Register all test post types and their revisioned meta keys.
+	 * Registers all test post types and their revisioned meta keys.
 	 */
 	public static function register(): void {
 		foreach ( self::definitions() as $slug => $args ) {

--- a/advanced-revisions-dev/src/TestPostTypes.php
+++ b/advanced-revisions-dev/src/TestPostTypes.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev;
+
+/**
+ * Registers test custom post types for exercising Advanced Revisions against a
+ * realistic post-type matrix. Loaded only when the dev plugin is activated;
+ * never present in production installs.
+ */
+final class TestPostTypes {
+
+	/**
+	 * Register all test post types and their revisioned meta keys.
+	 */
+	public static function register(): void {
+		foreach ( self::definitions() as $slug => $args ) {
+			register_post_type( $slug, $args );
+		}
+
+		register_post_meta(
+			'ar_test_product',
+			'_ar_test_product_price',
+			[
+				'type'         => 'string',
+				'single'       => true,
+				'show_in_rest' => true,
+			],
+		);
+	}
+
+	/**
+	 * Post type definitions keyed by slug.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function definitions(): array {
+		return [
+			'ar_test_article' => self::article(),
+			'ar_test_page'    => self::page(),
+			'ar_test_product' => self::product(),
+			'ar_test_note'    => self::note(),
+			'ar_test_private' => self::private_doc(),
+		];
+	}
+
+	/**
+	 * Flat public post type with full revision support.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function article(): array {
+		return self::base( 'Articles', 'Article', 'ar_test_article' ) + [
+			'hierarchical' => false,
+			'supports'     => [ 'title', 'editor', 'excerpt', 'author', 'revisions' ],
+		];
+	}
+
+	/**
+	 * Hierarchical public post type — exercises parent/child admin UX.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function page(): array {
+		return self::base( 'Test Pages', 'Test Page', 'ar_test_page' ) + [
+			'hierarchical' => true,
+			'supports'     => [ 'title', 'editor', 'page-attributes', 'revisions' ],
+		];
+	}
+
+	/**
+	 * Post type with revisioned custom meta for exercising meta-revisioning (#9).
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function product(): array {
+		return self::base( 'Products', 'Product', 'ar_test_product' ) + [
+			'hierarchical' => false,
+			'supports'     => [ 'title', 'editor', 'author', 'custom-fields', 'revisions' ],
+		];
+	}
+
+	/**
+	 * Post type with revisions explicitly disabled — negative coverage.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function note(): array {
+		return self::base( 'Notes', 'Note', 'ar_test_note' ) + [
+			'hierarchical' => false,
+			'supports'     => [ 'title', 'editor' ],
+		];
+	}
+
+	/**
+	 * Non-public post type — exercises capability gating.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function private_doc(): array {
+		return self::base( 'Private Docs', 'Private Doc', 'ar_test_private', false ) + [
+			'publicly_queryable' => false,
+			'hierarchical'       => false,
+			'supports'           => [ 'title', 'editor', 'revisions' ],
+		];
+	}
+
+	/**
+	 * Shared defaults applied to every test post type.
+	 *
+	 * @param string $name            Plural label.
+	 * @param string $singular        Singular label.
+	 * @param string $capability_type Custom capability type so tests are not polluted by core-post caps.
+	 * @param bool   $is_public       Whether the CPT is public; defaults to true.
+	 * @return array<string, mixed>
+	 */
+	private static function base( string $name, string $singular, string $capability_type, bool $is_public = true ): array {
+		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- register_post_type args are a WP API shape, not a candidate for a typed object.
+		return [
+			'labels'          => [
+				'name'          => $name,
+				'singular_name' => $singular,
+			],
+			'public'          => $is_public,
+			'show_ui'         => true,
+			'show_in_menu'    => true,
+			'show_in_rest'    => true,
+			'capability_type' => $capability_type,
+			'map_meta_cap'    => true,
+		];
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentGeneratorTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentGeneratorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\ContentGenerator;
+use Apermo\AdvancedRevisionsDev\Fixtures\Randomizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ContentGenerator. Output shape is the contract ContentSeeder
+ * depends on, so we assert shape + determinism rather than exact strings.
+ */
+final class ContentGeneratorTest extends TestCase {
+
+	/**
+	 * Titles are always non-empty strings.
+	 */
+	public function test_title_is_non_empty_string(): void {
+		$generator = new ContentGenerator();
+		$rng       = new Randomizer( 42 );
+
+		self::assertNotEmpty( $generator->title( $rng ) );
+	}
+
+	/**
+	 * Same seed + same call sequence produces the same title.
+	 */
+	public function test_title_is_deterministic_for_same_seed(): void {
+		$generator = new ContentGenerator();
+
+		$a = $generator->title( new Randomizer( 42 ) );
+		$b = $generator->title( new Randomizer( 42 ) );
+
+		self::assertSame( $a, $b );
+	}
+
+	/**
+	 * Body has at least two paragraphs (joined by blank lines).
+	 */
+	public function test_body_has_at_least_two_paragraphs(): void {
+		$generator = new ContentGenerator();
+		$rng       = new Randomizer( 42 );
+
+		$body = $generator->body( $rng );
+		self::assertGreaterThanOrEqual( 2, \substr_count( $body, "\n\n" ) + 1 );
+	}
+
+	/**
+	 * The post() method returns the shape wp_insert_post() expects.
+	 */
+	public function test_post_returns_wp_insert_post_shape(): void {
+		$generator = new ContentGenerator();
+		$rng       = new Randomizer( 42 );
+
+		$post = $generator->post( $rng, 'ar_test_article', 7, 'publish', '2025-01-15 12:00:00' );
+
+		self::assertSame( 'ar_test_article', $post['post_type'] );
+		self::assertSame( 'publish', $post['post_status'] );
+		self::assertSame( 7, $post['post_author'] );
+		self::assertSame( '2025-01-15 12:00:00', $post['post_date_gmt'] );
+		self::assertSame( '2025-01-15 12:00:00', $post['post_date'] );
+		self::assertIsString( $post['post_title'] );
+		self::assertNotEmpty( $post['post_title'] );
+		self::assertIsString( $post['post_content'] );
+		self::assertIsString( $post['post_excerpt'] );
+	}
+
+	/**
+	 * Calls to post() are byte-identical for the same seed and inputs.
+	 */
+	public function test_post_is_deterministic_for_same_seed(): void {
+		$generator = new ContentGenerator();
+
+		$a = $generator->post(
+			new Randomizer( 42 ),
+			'ar_test_article',
+			7,
+			'publish',
+			'2025-01-15 12:00:00',
+		);
+		$b = $generator->post(
+			new Randomizer( 42 ),
+			'ar_test_article',
+			7,
+			'publish',
+			'2025-01-15 12:00:00',
+		);
+
+		self::assertSame( $a, $b );
+	}
+
+	/**
+	 * Excerpts are sometimes empty and sometimes not across 200 seeds.
+	 */
+	public function test_excerpt_may_be_empty(): void {
+		$generator = new ContentGenerator();
+
+		$saw_empty     = false;
+		$saw_non_empty = false;
+
+		for ( $seed = 1; $seed <= 200 && ! ( $saw_empty && $saw_non_empty ); $seed++ ) {
+			$excerpt = $generator->excerpt( new Randomizer( $seed ) );
+			if ( $excerpt === '' ) {
+				$saw_empty = true;
+			} else {
+				$saw_non_empty = true;
+			}
+		}
+
+		self::assertTrue( $saw_empty, 'Expected at least one empty excerpt across 200 seeds' );
+		self::assertTrue( $saw_non_empty, 'Expected at least one non-empty excerpt across 200 seeds' );
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentGeneratorTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentGeneratorTest.php
@@ -25,7 +25,7 @@ final class ContentGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Same seed + same call sequence produces the same title.
+	 * Asserts the same seed plus same call sequence produces the same title.
 	 */
 	public function test_title_is_deterministic_for_same_seed(): void {
 		$generator = new ContentGenerator();
@@ -37,7 +37,7 @@ final class ContentGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Body has at least two paragraphs (joined by blank lines).
+	 * Asserts body has at least two paragraphs (joined by blank lines).
 	 */
 	public function test_body_has_at_least_two_paragraphs(): void {
 		$generator = new ContentGenerator();
@@ -48,7 +48,7 @@ final class ContentGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * The post() method returns the shape wp_insert_post() expects.
+	 * Asserts the post() method returns the shape wp_insert_post() expects.
 	 */
 	public function test_post_returns_wp_insert_post_shape(): void {
 		$generator = new ContentGenerator();

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
@@ -12,7 +12,7 @@ use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for ContentSeeder::seed(). The reset() path exercises WP_Query
+ * Covers ContentSeeder::seed() with unit tests. The reset() path exercises WP_Query
  * which is awkward to stub in unit tests — it's covered by integration tests.
  */
 final class ContentSeederTest extends TestCase {
@@ -97,7 +97,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * Seeder inserts the requested count of posts per target post type.
+	 * Asserts the seeder inserts the requested count of posts per target post type.
 	 */
 	public function test_seed_inserts_requested_count_per_post_type(): void {
 		$seeder = new ContentSeeder( new ContentGenerator() );
@@ -124,7 +124,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * Every inserted post is tagged with the seeded-post marker meta.
+	 * Asserts every inserted post is tagged with the seeded-post marker meta.
 	 */
 	public function test_seed_tags_every_inserted_post_with_marker_meta(): void {
 		$seeder = new ContentSeeder( new ContentGenerator() );
@@ -148,7 +148,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * The selected post type is passed through to wp_insert_post.
+	 * Asserts the selected post type is passed through to wp_insert_post.
 	 */
 	public function test_seed_passes_correct_post_type_to_wp_insert_post(): void {
 		$seeder = new ContentSeeder( new ContentGenerator() );
@@ -169,7 +169,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * Post status comes from the configured status-mix preset.
+	 * Asserts post status comes from the configured status-mix preset.
 	 */
 	public function test_seed_assigns_post_status_from_preset(): void {
 		$seeder = new ContentSeeder( new ContentGenerator() );
@@ -191,7 +191,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * Missing authors are created via wp_insert_user.
+	 * Asserts missing authors are created via wp_insert_user.
 	 */
 	public function test_seed_creates_authors_when_none_exist(): void {
 		$inserted_users = 0;
@@ -220,7 +220,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * When wp_insert_post returns a WP_Error, the post is skipped and no meta is written.
+	 * Asserts that when wp_insert_post returns a WP_Error, the post is skipped and no meta is written.
 	 */
 	public function test_seed_skips_posts_when_wp_insert_post_returns_error(): void {
 		Functions\when( 'wp_insert_post' )->justReturn( 'sentinel-error' );
@@ -246,7 +246,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * An empty post-types list returns an empty totals map without inserting anything.
+	 * Asserts an empty post-types list returns an empty totals map without inserting anything.
 	 */
 	public function test_seed_with_empty_post_types_returns_empty(): void {
 		$seeder = new ContentSeeder( new ContentGenerator() );

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
@@ -46,7 +46,7 @@ final class ContentSeederTest extends TestCase {
 	private int $next_user_id = 100;
 
 	/**
-	 * Set up Brain Monkey and default WP function stubs for every test.
+	 * Sets up Brain Monkey and default WP function stubs for every test.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -89,7 +89,7 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
@@ -220,10 +220,14 @@ final class ContentSeederTest extends TestCase {
 	}
 
 	/**
-	 * When wp_insert_post silently returns 0, the post is skipped and no meta is written.
+	 * When wp_insert_post returns a WP_Error, the post is skipped and no meta is written.
 	 */
 	public function test_seed_skips_posts_when_wp_insert_post_returns_error(): void {
-		Functions\when( 'wp_insert_post' )->justReturn( 0 );
+		Functions\when( 'wp_insert_post' )->justReturn( 'sentinel-error' );
+		// Treat only the wp_insert_post return as an error; wp_insert_user's int return must stay OK.
+		Functions\when( 'is_wp_error' )->alias(
+			static fn( mixed $value ): bool => $value === 'sentinel-error',
+		);
 
 		$seeder = new ContentSeeder( new ContentGenerator() );
 		$totals = $seeder->seed(

--- a/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/ContentSeederTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\ContentGenerator;
+use Apermo\AdvancedRevisionsDev\Fixtures\ContentSeeder;
+use Apermo\AdvancedRevisionsDev\Fixtures\Marker;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContentSeeder::seed(). The reset() path exercises WP_Query
+ * which is awkward to stub in unit tests — it's covered by integration tests.
+ */
+final class ContentSeederTest extends TestCase {
+
+	/**
+	 * Captured wp_insert_post payloads from the active test.
+	 *
+	 * @var list<array<string, mixed>>
+	 */
+	private array $inserted = [];
+
+	/**
+	 * Captured update_post_meta calls from the active test.
+	 *
+	 * @var list<array{id:int,key:string,value:string}>
+	 */
+	private array $meta_updates = [];
+
+	/**
+	 * Post ID counter handed out by the stubbed wp_insert_post.
+	 *
+	 * @var int
+	 */
+	private int $next_post_id = 1;
+
+	/**
+	 * User ID counter handed out by the stubbed wp_insert_user.
+	 *
+	 * @var int
+	 */
+	private int $next_user_id = 100;
+
+	/**
+	 * Set up Brain Monkey and default WP function stubs for every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->inserted     = [];
+		$this->meta_updates = [];
+		$this->next_post_id = 1;
+		$this->next_user_id = 100;
+
+		Functions\when( 'wp_insert_post' )->alias(
+			function ( array $data ): int {
+				$id = $this->next_post_id;
+				$this->next_post_id++;
+				$data['_assigned_id'] = $id;
+				$this->inserted[]     = $data;
+				return $id;
+			},
+		);
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'update_post_meta' )->alias(
+			function ( int $id, string $key, string $value ): void {
+				$this->meta_updates[] = [
+					'id'    => $id,
+					'key'   => $key,
+					'value' => $value,
+				];
+			},
+		);
+		Functions\when( 'get_user_by' )->justReturn( false );
+		Functions\when( 'wp_insert_user' )->alias(
+			function ( array $args ): int {
+				unset( $args );
+				$id = $this->next_user_id;
+				$this->next_user_id++;
+				return $id;
+			},
+		);
+		Functions\when( 'wp_generate_password' )->justReturn( 'fake-password-for-tests' );
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Seeder inserts the requested count of posts per target post type.
+	 */
+	public function test_seed_inserts_requested_count_per_post_type(): void {
+		$seeder = new ContentSeeder( new ContentGenerator() );
+
+		$totals = $seeder->seed(
+			[
+				'count'       => 3,
+				'seed'        => 42,
+				'authors'     => 2,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_article', 'ar_test_page' ],
+			],
+		);
+
+		self::assertSame(
+			[
+				'ar_test_article' => 3,
+				'ar_test_page'    => 3,
+			],
+			$totals,
+		);
+		self::assertCount( 6, $this->inserted );
+	}
+
+	/**
+	 * Every inserted post is tagged with the seeded-post marker meta.
+	 */
+	public function test_seed_tags_every_inserted_post_with_marker_meta(): void {
+		$seeder = new ContentSeeder( new ContentGenerator() );
+
+		$seeder->seed(
+			[
+				'count'       => 2,
+				'seed'        => 42,
+				'authors'     => 1,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_article' ],
+			],
+		);
+
+		self::assertCount( 2, $this->meta_updates );
+		foreach ( $this->meta_updates as $update ) {
+			self::assertSame( Marker::SEEDED_POST, $update['key'] );
+			self::assertSame( Marker::YES, $update['value'] );
+		}
+	}
+
+	/**
+	 * The selected post type is passed through to wp_insert_post.
+	 */
+	public function test_seed_passes_correct_post_type_to_wp_insert_post(): void {
+		$seeder = new ContentSeeder( new ContentGenerator() );
+
+		$seeder->seed(
+			[
+				'count'       => 1,
+				'seed'        => 42,
+				'authors'     => 1,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_product', 'ar_test_note' ],
+			],
+		);
+
+		self::assertSame( 'ar_test_product', $this->inserted[0]['post_type'] );
+		self::assertSame( 'ar_test_note', $this->inserted[1]['post_type'] );
+	}
+
+	/**
+	 * Post status comes from the configured status-mix preset.
+	 */
+	public function test_seed_assigns_post_status_from_preset(): void {
+		$seeder = new ContentSeeder( new ContentGenerator() );
+
+		$seeder->seed(
+			[
+				'count'       => 5,
+				'seed'        => 42,
+				'authors'     => 1,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_article' ],
+			],
+		);
+
+		foreach ( $this->inserted as $post ) {
+			self::assertSame( 'publish', $post['post_status'] );
+		}
+	}
+
+	/**
+	 * Missing authors are created via wp_insert_user.
+	 */
+	public function test_seed_creates_authors_when_none_exist(): void {
+		$inserted_users = 0;
+		Functions\when( 'wp_insert_user' )->alias(
+			static function ( array $args ) use ( &$inserted_users ): int {
+				unset( $args );
+				$id = 100 + $inserted_users;
+				$inserted_users++;
+				return $id;
+			},
+		);
+
+		$seeder = new ContentSeeder( new ContentGenerator() );
+		$seeder->seed(
+			[
+				'count'       => 1,
+				'seed'        => 42,
+				'authors'     => 4,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_article' ],
+			],
+		);
+
+		self::assertSame( 4, $inserted_users );
+	}
+
+	/**
+	 * When wp_insert_post silently returns 0, the post is skipped and no meta is written.
+	 */
+	public function test_seed_skips_posts_when_wp_insert_post_returns_error(): void {
+		Functions\when( 'wp_insert_post' )->justReturn( 0 );
+
+		$seeder = new ContentSeeder( new ContentGenerator() );
+		$totals = $seeder->seed(
+			[
+				'count'       => 3,
+				'seed'        => 42,
+				'authors'     => 1,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [ 'ar_test_article' ],
+			],
+		);
+
+		self::assertSame( [ 'ar_test_article' => 0 ], $totals );
+		self::assertSame( [], $this->meta_updates );
+	}
+
+	/**
+	 * An empty post-types list returns an empty totals map without inserting anything.
+	 */
+	public function test_seed_with_empty_post_types_returns_empty(): void {
+		$seeder = new ContentSeeder( new ContentGenerator() );
+
+		$totals = $seeder->seed(
+			[
+				'count'       => 10,
+				'seed'        => 42,
+				'authors'     => 1,
+				'date_spread' => 30,
+				'status_mix'  => 'publish',
+				'post_types'  => [],
+			],
+		);
+
+		self::assertSame( [], $totals );
+		self::assertSame( [], $this->inserted );
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/MarkerTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/MarkerTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class MarkerTest extends TestCase {
 
 	/**
-	 * Author login uses the configured prefix with a 1-based index.
+	 * Asserts author login uses the configured prefix with a 1-based index.
 	 */
 	public function test_author_login_uses_one_indexed_numbers(): void {
 		self::assertSame( 'ar_test_author_1', Marker::author_login( 1 ) );
@@ -21,7 +21,7 @@ final class MarkerTest extends TestCase {
 	}
 
 	/**
-	 * Author email uses the example.tld safe domain.
+	 * Asserts author email uses the example.tld safe domain.
 	 */
 	public function test_author_email_uses_example_tld(): void {
 		self::assertSame(
@@ -31,7 +31,7 @@ final class MarkerTest extends TestCase {
 	}
 
 	/**
-	 * Post and revision marker keys are distinct so resetters don't cross-delete.
+	 * Asserts post and revision marker keys are distinct so resetters don't cross-delete.
 	 */
 	public function test_seeded_post_meta_key_differs_from_revision(): void {
 		self::assertNotSame( Marker::SEEDED_POST, Marker::SEEDED_REVISION );

--- a/advanced-revisions-dev/tests/Unit/Fixtures/MarkerTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/MarkerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\Marker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Marker constants and helpers.
+ */
+final class MarkerTest extends TestCase {
+
+	/**
+	 * Author login uses the configured prefix with a 1-based index.
+	 */
+	public function test_author_login_uses_one_indexed_numbers(): void {
+		self::assertSame( 'ar_test_author_1', Marker::author_login( 1 ) );
+		self::assertSame( 'ar_test_author_42', Marker::author_login( 42 ) );
+	}
+
+	/**
+	 * Author email uses the example.tld safe domain.
+	 */
+	public function test_author_email_uses_example_tld(): void {
+		self::assertSame(
+			'ar_test_author_1@example.tld',
+			Marker::author_email( 1 ),
+		);
+	}
+
+	/**
+	 * Post and revision marker keys are distinct so resetters don't cross-delete.
+	 */
+	public function test_seeded_post_meta_key_differs_from_revision(): void {
+		self::assertNotSame( Marker::SEEDED_POST, Marker::SEEDED_REVISION );
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RandomizerTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RandomizerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\Randomizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Randomizer PRNG wrapper. Determinism is the contract that
+ * matters most — fixtures rely on reproducible seeds.
+ *
+ * Note: mt_srand()/mt_rand() share global PHP state, so tests must exhaust
+ * one Randomizer before creating another. This matches how the seeder uses
+ * Randomizer in practice (one instance per WP-CLI command run).
+ */
+final class RandomizerTest extends TestCase {
+
+	/**
+	 * Same seed produces identical sequence when consumed sequentially.
+	 */
+	public function test_same_seed_produces_same_sequence(): void {
+		$sequence_a = [];
+		$rng_a      = new Randomizer( 42 );
+		for ( $i = 0; $i < 20; $i++ ) {
+			$sequence_a[] = $rng_a->int_between( 0, 1_000 );
+		}
+
+		$sequence_b = [];
+		$rng_b      = new Randomizer( 42 );
+		for ( $i = 0; $i < 20; $i++ ) {
+			$sequence_b[] = $rng_b->int_between( 0, 1_000 );
+		}
+
+		self::assertSame( $sequence_a, $sequence_b );
+	}
+
+	/**
+	 * Different seeds diverge within a small window.
+	 */
+	public function test_different_seeds_diverge(): void {
+		$sequence_a = [];
+		$rng_a      = new Randomizer( 42 );
+		for ( $i = 0; $i < 20; $i++ ) {
+			$sequence_a[] = $rng_a->int_between( 0, 1_000 );
+		}
+
+		$sequence_b = [];
+		$rng_b      = new Randomizer( 7 );
+		for ( $i = 0; $i < 20; $i++ ) {
+			$sequence_b[] = $rng_b->int_between( 0, 1_000 );
+		}
+
+		self::assertNotSame( $sequence_a, $sequence_b );
+	}
+
+	/**
+	 * Bounds passed to int_between are inclusive on both ends.
+	 */
+	public function test_int_between_bounds_are_inclusive(): void {
+		$rng = new Randomizer( 1 );
+
+		for ( $i = 0; $i < 100; $i++ ) {
+			$value = $rng->int_between( 5, 10 );
+			self::assertGreaterThanOrEqual( 5, $value );
+			self::assertLessThanOrEqual( 10, $value );
+		}
+	}
+
+	/**
+	 * Picking from an empty list returns null rather than throwing.
+	 */
+	public function test_pick_returns_null_for_empty_list(): void {
+		$rng = new Randomizer( 1 );
+
+		self::assertNull( $rng->pick( [] ) );
+	}
+
+	/**
+	 * Picking always returns an element of the input list.
+	 */
+	public function test_pick_returns_element_from_list(): void {
+		$rng     = new Randomizer( 42 );
+		$choices = [ 'a', 'b', 'c' ];
+
+		for ( $i = 0; $i < 20; $i++ ) {
+			self::assertContains( $rng->pick( $choices ), $choices );
+		}
+	}
+
+	/**
+	 * Probability values stay in the half-open interval [0, 1).
+	 */
+	public function test_probability_is_bounded(): void {
+		$rng = new Randomizer( 123 );
+
+		for ( $i = 0; $i < 100; $i++ ) {
+			$value = $rng->probability();
+			self::assertGreaterThanOrEqual( 0.0, $value );
+			self::assertLessThan( 1.0, $value );
+		}
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RandomizerTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RandomizerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class RandomizerTest extends TestCase {
 
 	/**
-	 * Same seed produces identical sequence when consumed sequentially.
+	 * Asserts the same seed produces an identical sequence when consumed sequentially.
 	 */
 	public function test_same_seed_produces_same_sequence(): void {
 		$sequence_a = [];
@@ -37,7 +37,7 @@ final class RandomizerTest extends TestCase {
 	}
 
 	/**
-	 * Different seeds diverge within a small window.
+	 * Asserts different seeds diverge within a small window.
 	 */
 	public function test_different_seeds_diverge(): void {
 		$sequence_a = [];
@@ -69,7 +69,7 @@ final class RandomizerTest extends TestCase {
 	}
 
 	/**
-	 * Picking from an empty list returns null rather than throwing.
+	 * Asserts picking from an empty list returns null rather than throwing.
 	 */
 	public function test_pick_returns_null_for_empty_list(): void {
 		$rng = new Randomizer( 1 );
@@ -78,7 +78,7 @@ final class RandomizerTest extends TestCase {
 	}
 
 	/**
-	 * Picking always returns an element of the input list.
+	 * Asserts picking always returns an element of the input list.
 	 */
 	public function test_pick_returns_element_from_list(): void {
 		$rng     = new Randomizer( 42 );
@@ -90,7 +90,7 @@ final class RandomizerTest extends TestCase {
 	}
 
 	/**
-	 * Probability values stay in the half-open interval [0, 1).
+	 * Asserts probability values stay in the half-open interval [0, 1).
 	 */
 	public function test_probability_is_bounded(): void {
 		$rng = new Randomizer( 123 );

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RevisionGeneratorTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RevisionGeneratorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 final class RevisionGeneratorTest extends TestCase {
 
 	/**
-	 * Mutated body always differs from the original by at least one character.
+	 * Asserts the mutated body always differs from the original by at least one character.
 	 */
 	public function test_mutated_body_changes_original(): void {
 		$generator = new RevisionGenerator();
@@ -28,7 +28,7 @@ final class RevisionGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Same seed + inputs produce identical mutated body.
+	 * Asserts the same seed plus inputs produce an identical mutated body.
 	 */
 	public function test_mutated_body_is_deterministic(): void {
 		$generator = new RevisionGenerator();
@@ -40,7 +40,7 @@ final class RevisionGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Mutated body preserves the original text as a prefix, so diffs are additive.
+	 * Asserts the mutated body preserves the original text as a prefix, so diffs are additive.
 	 */
 	public function test_mutated_body_preserves_original_as_prefix(): void {
 		$generator = new RevisionGenerator();
@@ -51,7 +51,7 @@ final class RevisionGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Mutated title is usually the same as the original (only ~10% mutated).
+	 * Asserts the mutated title is usually the same as the original (only ~10% mutated).
 	 */
 	public function test_mutated_title_is_usually_unchanged(): void {
 		$generator = new RevisionGenerator();
@@ -68,7 +68,7 @@ final class RevisionGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Mutated title sometimes differs (otherwise we'd never test title diffs).
+	 * Asserts the mutated title sometimes differs (otherwise we'd never test title diffs).
 	 */
 	public function test_mutated_title_sometimes_changes(): void {
 		$generator = new RevisionGenerator();

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RevisionGeneratorTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RevisionGeneratorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\Randomizer;
+use Apermo\AdvancedRevisionsDev\Fixtures\RevisionGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for RevisionGenerator. Diffs between revisions must be visible in the
+ * native compare screen, so every mutation must change something.
+ */
+final class RevisionGeneratorTest extends TestCase {
+
+	/**
+	 * Mutated body always differs from the original by at least one character.
+	 */
+	public function test_mutated_body_changes_original(): void {
+		$generator = new RevisionGenerator();
+		$original  = 'The quick brown fox';
+
+		for ( $seed = 1; $seed <= 20; $seed++ ) {
+			$mutated = $generator->mutated_body( new Randomizer( $seed ), $original, 1 );
+			self::assertNotSame( $original, $mutated );
+		}
+	}
+
+	/**
+	 * Same seed + inputs produce identical mutated body.
+	 */
+	public function test_mutated_body_is_deterministic(): void {
+		$generator = new RevisionGenerator();
+
+		$a = $generator->mutated_body( new Randomizer( 42 ), 'Hello', 3 );
+		$b = $generator->mutated_body( new Randomizer( 42 ), 'Hello', 3 );
+
+		self::assertSame( $a, $b );
+	}
+
+	/**
+	 * Mutated body preserves the original text as a prefix, so diffs are additive.
+	 */
+	public function test_mutated_body_preserves_original_as_prefix(): void {
+		$generator = new RevisionGenerator();
+		$original  = 'Original paragraph.';
+
+		$mutated = $generator->mutated_body( new Randomizer( 42 ), $original, 1 );
+		self::assertStringStartsWith( $original, $mutated );
+	}
+
+	/**
+	 * Mutated title is usually the same as the original (only ~10% mutated).
+	 */
+	public function test_mutated_title_is_usually_unchanged(): void {
+		$generator = new RevisionGenerator();
+		$original  = 'Title';
+
+		$unchanged = 0;
+		for ( $seed = 1; $seed <= 100; $seed++ ) {
+			if ( $generator->mutated_title( new Randomizer( $seed ), $original ) === $original ) {
+				$unchanged++;
+			}
+		}
+
+		self::assertGreaterThan( 50, $unchanged, 'Expected most titles to remain unchanged' );
+	}
+
+	/**
+	 * Mutated title sometimes differs (otherwise we'd never test title diffs).
+	 */
+	public function test_mutated_title_sometimes_changes(): void {
+		$generator = new RevisionGenerator();
+		$original  = 'Title';
+
+		$changed = false;
+		for ( $seed = 1; $seed <= 200 && ! $changed; $seed++ ) {
+			if ( $generator->mutated_title( new Randomizer( $seed ), $original ) !== $original ) {
+				$changed = true;
+			}
+		}
+
+		self::assertTrue( $changed, 'Expected at least one title mutation across 200 seeds' );
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use WP_Post;
 
 /**
- * Unit tests for RevisionSeeder::seed(). reset() uses WP_Query and is covered
+ * Covers RevisionSeeder::seed() with unit tests. reset() uses WP_Query and is covered
  * by integration tests.
  */
 final class RevisionSeederTest extends TestCase {
@@ -92,7 +92,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Every inserted revision row carries the seeded-revision marker meta.
+	 * Asserts every inserted revision row carries the seeded-revision marker meta.
 	 */
 	public function test_seed_tags_rows_with_marker_meta(): void {
 		$seeder = new RevisionSeeder( new RevisionGenerator() );
@@ -116,7 +116,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Distribution preset bounds the revision count for each post.
+	 * Asserts the distribution preset bounds the revision count for each post.
 	 */
 	public function test_sparse_distribution_produces_at_most_five_rows_per_post(): void {
 		$seeder = new RevisionSeeder( new RevisionGenerator() );
@@ -137,7 +137,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Autosave ratio routes some rows to autosave post_name pattern.
+	 * Asserts the autosave ratio routes some rows to the autosave post_name pattern.
 	 */
 	public function test_autosave_ratio_produces_autosave_suffix_names(): void {
 		$seeder = new RevisionSeeder( new RevisionGenerator() );
@@ -165,7 +165,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Every non-orphan row links to the correct parent post ID.
+	 * Asserts every non-orphan row links to the correct parent post ID.
 	 */
 	public function test_seed_uses_post_type_revision_and_inherit_status(): void {
 		$seeder = new RevisionSeeder( new RevisionGenerator() );
@@ -189,7 +189,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Orphan count produces that many rows with a non-existent post_parent.
+	 * Asserts the orphan count produces that many rows with a non-existent post_parent.
 	 */
 	public function test_orphan_count_creates_orphan_rows(): void {
 		$seeder = new RevisionSeeder( new RevisionGenerator() );

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
@@ -40,7 +40,7 @@ final class RevisionSeederTest extends TestCase {
 	private int $next_id = 9001;
 
 	/**
-	 * Set up Brain Monkey and default WP function stubs.
+	 * Sets up Brain Monkey and default WP function stubs.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -84,7 +84,7 @@ final class RevisionSeederTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
+++ b/advanced-revisions-dev/tests/Unit/Fixtures/RevisionSeederTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit\Fixtures;
+
+use Apermo\AdvancedRevisionsDev\Fixtures\Marker;
+use Apermo\AdvancedRevisionsDev\Fixtures\RevisionGenerator;
+use Apermo\AdvancedRevisionsDev\Fixtures\RevisionSeeder;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Unit tests for RevisionSeeder::seed(). reset() uses WP_Query and is covered
+ * by integration tests.
+ */
+final class RevisionSeederTest extends TestCase {
+
+	/**
+	 * Captured wp_insert_post payloads.
+	 *
+	 * @var list<array<string, mixed>>
+	 */
+	private array $inserted = [];
+
+	/**
+	 * Captured update_post_meta calls.
+	 *
+	 * @var list<array{id:int,key:string,value:string}>
+	 */
+	private array $meta_updates = [];
+
+	/**
+	 * Row ID counter.
+	 *
+	 * @var int
+	 */
+	private int $next_id = 9001;
+
+	/**
+	 * Set up Brain Monkey and default WP function stubs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->inserted     = [];
+		$this->meta_updates = [];
+		$this->next_id      = 9001;
+
+		Functions\when( 'wp_insert_post' )->alias(
+			function ( array $data ): int {
+				$id = $this->next_id;
+				$this->next_id++;
+				$data['_assigned_id'] = $id;
+				$this->inserted[]     = $data;
+				return $id;
+			},
+		);
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'update_post_meta' )->alias(
+			function ( int $id, string $key, string $value ): void {
+				$this->meta_updates[] = [
+					'id'    => $id,
+					'key'   => $key,
+					'value' => $value,
+				];
+			},
+		);
+		Functions\when( 'get_post' )->alias(
+			// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
+			static function ( int $id ): WP_Post {
+				$post               = new WP_Post();
+				$post->ID           = $id;
+				$post->post_type    = 'ar_test_article';
+				$post->post_title   = 'Parent #' . $id;
+				$post->post_content = 'Parent body #' . $id;
+				$post->post_author  = '1';
+				return $post;
+			},
+		);
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Every inserted revision row carries the seeded-revision marker meta.
+	 */
+	public function test_seed_tags_rows_with_marker_meta(): void {
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+
+		$seeder->seed(
+			[ 100 ],
+			[
+				'distribution'   => 'normal',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.0,
+				'orphan_count'   => 0,
+			],
+		);
+
+		self::assertCount( \count( $this->inserted ), $this->meta_updates );
+		foreach ( $this->meta_updates as $update ) {
+			self::assertSame( Marker::SEEDED_REVISION, $update['key'] );
+			self::assertSame( Marker::YES, $update['value'] );
+		}
+	}
+
+	/**
+	 * Distribution preset bounds the revision count for each post.
+	 */
+	public function test_sparse_distribution_produces_at_most_five_rows_per_post(): void {
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+
+		$stats = $seeder->seed(
+			[ 100 ],
+			[
+				'distribution'   => 'sparse',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.0,
+				'orphan_count'   => 0,
+			],
+		);
+
+		self::assertGreaterThanOrEqual( 0, $stats['revisions'] );
+		self::assertLessThanOrEqual( 5, $stats['revisions'] );
+	}
+
+	/**
+	 * Autosave ratio routes some rows to autosave post_name pattern.
+	 */
+	public function test_autosave_ratio_produces_autosave_suffix_names(): void {
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+
+		$seeder->seed(
+			[ 100 ],
+			[
+				'distribution'   => 'heavy',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.5,
+				'orphan_count'   => 0,
+			],
+		);
+
+		$has_autosave_name = false;
+		foreach ( $this->inserted as $row_data ) {
+			if ( \str_contains( (string) $row_data['post_name'], '-autosave-v' ) ) {
+				$has_autosave_name = true;
+				break;
+			}
+		}
+
+		self::assertTrue( $has_autosave_name, 'Expected at least one autosave row with -autosave-v post_name' );
+	}
+
+	/**
+	 * Every non-orphan row links to the correct parent post ID.
+	 */
+	public function test_seed_uses_post_type_revision_and_inherit_status(): void {
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+
+		$seeder->seed(
+			[ 100 ],
+			[
+				'distribution'   => 'normal',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.0,
+				'orphan_count'   => 0,
+			],
+		);
+
+		foreach ( $this->inserted as $row_data ) {
+			self::assertSame( 'revision', $row_data['post_type'] );
+			self::assertSame( 'inherit', $row_data['post_status'] );
+			self::assertSame( 100, $row_data['post_parent'] );
+		}
+	}
+
+	/**
+	 * Orphan count produces that many rows with a non-existent post_parent.
+	 */
+	public function test_orphan_count_creates_orphan_rows(): void {
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+
+		$stats = $seeder->seed(
+			[],
+			[
+				'distribution'   => 'normal',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.0,
+				'orphan_count'   => 7,
+			],
+		);
+
+		self::assertSame( 7, $stats['orphans'] );
+		$orphan_rows = \array_filter(
+			$this->inserted,
+			static fn( array $row_data ): bool => (int) $row_data['post_parent'] >= 999_000_000,
+		);
+		self::assertCount( 7, $orphan_rows );
+	}
+
+	/**
+	 * Posts with no matching get_post() (nullable return) are skipped silently.
+	 */
+	public function test_seed_skips_missing_posts(): void {
+		Functions\when( 'get_post' )->justReturn( null );
+
+		$seeder = new RevisionSeeder( new RevisionGenerator() );
+		$stats  = $seeder->seed(
+			[ 100, 200 ],
+			[
+				'distribution'   => 'normal',
+				'seed'           => 42,
+				'spread_days'    => 30,
+				'autosave_ratio' => 0.0,
+				'orphan_count'   => 0,
+			],
+		);
+
+		self::assertSame( 0, $stats['revisions'] );
+		self::assertSame( 0, $stats['autosaves'] );
+		self::assertSame( [], $this->inserted );
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
+++ b/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisionsDev\Tests\Unit;
+
+use Apermo\AdvancedRevisionsDev\TestPostTypes;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for TestPostTypes.
+ */
+final class TestPostTypesTest extends TestCase {
+
+	/**
+	 * Captured register_post_type calls from the last TestPostTypes::register() run.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $registered = [];
+
+	/**
+	 * Captured register_post_meta calls from the last TestPostTypes::register() run.
+	 *
+	 * @var list<array{type: string, key: string, args: array<string, mixed>}>
+	 */
+	private array $meta = [];
+
+	/**
+	 * Set up Brain Monkey and default function stubs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->registered = [];
+		$this->meta       = [];
+
+		Functions\when( 'register_post_type' )->alias(
+			function ( string $type, array $args ): void {
+				$this->registered[ $type ] = $args;
+			},
+		);
+		Functions\when( 'register_post_meta' )->alias(
+			function ( string $type, string $key, array $args ): void {
+				$this->meta[] = [
+					'type' => $type,
+					'key'  => $key,
+					'args' => $args,
+				];
+			},
+		);
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * All five test post types are registered.
+	 */
+	public function test_register_registers_five_post_types(): void {
+		TestPostTypes::register();
+
+		$this->assertCount( 5, $this->registered );
+		$this->assertSame(
+			[ 'ar_test_article', 'ar_test_page', 'ar_test_product', 'ar_test_note', 'ar_test_private' ],
+			\array_keys( $this->registered ),
+		);
+	}
+
+	/**
+	 * Article supports revisions.
+	 */
+	public function test_article_supports_revisions(): void {
+		TestPostTypes::register();
+
+		$this->assertContains( 'revisions', $this->registered['ar_test_article']['supports'] );
+	}
+
+	/**
+	 * Page is hierarchical.
+	 */
+	public function test_page_is_hierarchical(): void {
+		TestPostTypes::register();
+
+		$this->assertTrue( $this->registered['ar_test_page']['hierarchical'] );
+	}
+
+	/**
+	 * Product registers a revisioned meta key for exercising #9.
+	 */
+	public function test_product_registers_meta(): void {
+		TestPostTypes::register();
+
+		$this->assertCount( 1, $this->meta );
+		$this->assertSame( 'ar_test_product', $this->meta[0]['type'] );
+		$this->assertSame( '_ar_test_product_price', $this->meta[0]['key'] );
+		$this->assertTrue( $this->meta[0]['args']['show_in_rest'] );
+	}
+
+	/**
+	 * Note intentionally excludes revisions so "revisions disabled" scenarios are covered.
+	 */
+	public function test_note_does_not_support_revisions(): void {
+		TestPostTypes::register();
+
+		$this->assertNotContains( 'revisions', $this->registered['ar_test_note']['supports'] );
+	}
+
+	/**
+	 * Private doc is not public so capability gating can be exercised.
+	 */
+	public function test_private_is_not_public(): void {
+		TestPostTypes::register();
+
+		$this->assertFalse( $this->registered['ar_test_private']['public'] );
+		$this->assertFalse( $this->registered['ar_test_private']['publicly_queryable'] );
+	}
+
+	/**
+	 * Every registered type uses its own capability type so tests aren't polluted
+	 * by core-post capabilities.
+	 */
+	public function test_each_type_has_own_capability_type(): void {
+		TestPostTypes::register();
+
+		foreach ( $this->registered as $slug => $args ) {
+			$this->assertSame( $slug, $args['capability_type'], "CPT {$slug} should use its own capability_type" );
+			$this->assertTrue( $args['map_meta_cap'], "CPT {$slug} should map meta caps" );
+		}
+	}
+
+	/**
+	 * All types are REST-visible so the block editor can use them.
+	 */
+	public function test_all_types_are_rest_visible(): void {
+		TestPostTypes::register();
+
+		foreach ( $this->registered as $slug => $args ) {
+			$this->assertTrue( $args['show_in_rest'], "CPT {$slug} should be REST-visible" );
+		}
+	}
+}

--- a/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
+++ b/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
@@ -29,7 +29,7 @@ final class TestPostTypesTest extends TestCase {
 	private array $meta = [];
 
 	/**
-	 * Set up Brain Monkey and default function stubs.
+	 * Sets up Brain Monkey and default function stubs.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -55,7 +55,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
+++ b/advanced-revisions-dev/tests/Unit/TestPostTypesTest.php
@@ -63,7 +63,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * All five test post types are registered.
+	 * Asserts all five test post types are registered.
 	 */
 	public function test_register_registers_five_post_types(): void {
 		TestPostTypes::register();
@@ -76,7 +76,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Article supports revisions.
+	 * Asserts article supports revisions.
 	 */
 	public function test_article_supports_revisions(): void {
 		TestPostTypes::register();
@@ -85,7 +85,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Page is hierarchical.
+	 * Asserts page is hierarchical.
 	 */
 	public function test_page_is_hierarchical(): void {
 		TestPostTypes::register();
@@ -94,7 +94,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Product registers a revisioned meta key for exercising #9.
+	 * Asserts product registers a revisioned meta key for exercising #9.
 	 */
 	public function test_product_registers_meta(): void {
 		TestPostTypes::register();
@@ -106,7 +106,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Note intentionally excludes revisions so "revisions disabled" scenarios are covered.
+	 * Asserts note intentionally excludes revisions so "revisions disabled" scenarios are covered.
 	 */
 	public function test_note_does_not_support_revisions(): void {
 		TestPostTypes::register();
@@ -115,7 +115,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Private doc is not public so capability gating can be exercised.
+	 * Asserts private doc is not public so capability gating can be exercised.
 	 */
 	public function test_private_is_not_public(): void {
 		TestPostTypes::register();
@@ -125,7 +125,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * Every registered type uses its own capability type so tests aren't polluted
+	 * Asserts every registered type uses its own capability type so tests aren't polluted
 	 * by core-post capabilities.
 	 */
 	public function test_each_type_has_own_capability_type(): void {
@@ -138,7 +138,7 @@ final class TestPostTypesTest extends TestCase {
 	}
 
 	/**
-	 * All types are REST-visible so the block editor can use them.
+	 * Asserts all types are REST-visible so the block editor can use them.
 	 */
 	public function test_all_types_are_rest_visible(): void {
 		TestPostTypes::register();

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "autoload-dev": {
         "psr-4": {
             "Apermo\\AdvancedRevisions\\Tests\\": "tests/",
+            "Apermo\\AdvancedRevisions\\Tests\\Fixtures\\": "tests/Fixtures/",
             "Apermo\\AdvancedRevisionsDev\\": "advanced-revisions-dev/src/",
             "Apermo\\AdvancedRevisionsDev\\Tests\\": "advanced-revisions-dev/tests/"
         }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "apermo/apermo-coding-standards": "^2.0",
+        "apermo/apermo-coding-standards": "^2.8",
         "apermo/phpstan-wordpress-rules": "^0.2",
         "brain/monkey": "^2.6",
         "phpstan/extension-installer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "test": "phpunit",
         "test:unit": "phpunit --testsuite Unit",
         "test:integration": "phpunit --testsuite Integration",
-        "analyse": "phpstan analyse --memory-limit=512M",
+        "analyse": "phpstan analyse --memory-limit=1G",
         "cs": "phpcs",
         "cs:fix": "phpcbf"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Apermo\\AdvancedRevisions\\Tests\\": "tests/"
+            "Apermo\\AdvancedRevisions\\Tests\\": "tests/",
+            "Apermo\\AdvancedRevisionsDev\\": "advanced-revisions-dev/src/",
+            "Apermo\\AdvancedRevisionsDev\\Tests\\": "advanced-revisions-dev/tests/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "apermo/apermo-coding-standards": "^2.8",
+        "apermo/apermo-coding-standards": "^2.9",
         "apermo/phpstan-wordpress-rules": "^0.2",
         "brain/monkey": "^2.6",
         "phpstan/extension-installer": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea23b9ad10854d10e44332ecdaa18203",
+    "content-hash": "d718337c9a55d7faba1e77114e58b502",
     "packages": [],
     "packages-dev": [
         {
@@ -57,16 +57,16 @@
         },
         {
             "name": "apermo/apermo-coding-standards",
-            "version": "v2.6.1",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/apermo-coding-standards.git",
-                "reference": "6f7c7407a98de64c7adcc6f87e1135806fc63a66"
+                "reference": "dba8212d2656e1d48965ba86fa9911f8017b3ce6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/6f7c7407a98de64c7adcc6f87e1135806fc63a66",
-                "reference": "6f7c7407a98de64c7adcc6f87e1135806fc63a66",
+                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/dba8212d2656e1d48965ba86fa9911f8017b3ce6",
+                "reference": "dba8212d2656e1d48965ba86fa9911f8017b3ce6",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/apermo/apermo-coding-standards/issues",
                 "source": "https://github.com/apermo/apermo-coding-standards"
             },
-            "time": "2026-03-15T15:21:52+00:00"
+            "time": "2026-04-19T18:59:37+00:00"
         },
         {
             "name": "apermo/phpstan-wordpress-rules",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d718337c9a55d7faba1e77114e58b502",
+    "content-hash": "2ac9e11bab7e3496a62399968981de92",
     "packages": [],
     "packages-dev": [
         {
@@ -57,19 +57,20 @@
         },
         {
             "name": "apermo/apermo-coding-standards",
-            "version": "v2.8.0",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/apermo-coding-standards.git",
-                "reference": "dba8212d2656e1d48965ba86fa9911f8017b3ce6"
+                "reference": "36a507e08ca248c2e3074b38b7cc08910cfe1321"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/dba8212d2656e1d48965ba86fa9911f8017b3ce6",
-                "reference": "dba8212d2656e1d48965ba86fa9911f8017b3ce6",
+                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/36a507e08ca248c2e3074b38b7cc08910cfe1321",
+                "reference": "36a507e08ca248c2e3074b38b7cc08910cfe1321",
                 "shasum": ""
             },
             "require": {
+                "automattic/vipwpcs": "^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "php": ">=7.4",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -111,7 +112,7 @@
                 "issues": "https://github.com/apermo/apermo-coding-standards/issues",
                 "source": "https://github.com/apermo/apermo-coding-standards"
             },
-            "time": "2026-04-19T18:59:37+00:00"
+            "time": "2026-04-20T07:27:42+00:00"
         },
         {
             "name": "apermo/phpstan-wordpress-rules",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,16 +63,16 @@ this layer.
 
 | Issue | Feature                              | Unit | Integration | E2E | Fixture scenario  |
 |-------|--------------------------------------|:----:|:-----------:|:---:|-------------------|
-| #1    | Per-type revision limit              |  ✓   |             |     | `mixed-types`     |
-| #2    | Admin overview                       |  ✓   |             |     | `heavy-site`      |
-| #3    | Bulk delete from overview            |  ✓   |             |     | `heavy-site`      |
-| #4    | Post list column                     |  ✓   |             |     | `normal-site`     |
-| #10   | Dashboard widget                     |  ✓   |             |     | `normal-site`     |
-| #11   | Per-post override                    |  ✓   |             |     | `mixed-types`     |
-| #13   | Tagging + protection                 |  ✓   |             |     | `tagged-site`     |
-| #14   | Dev fixtures CPTs                    |  ✓   |             |     | n/a               |
-| #15   | Content seeder (WP-CLI)              |  ✓   |             |     | n/a               |
-| #16   | Revision seeder (WP-CLI)             |  ✓   |             |     | n/a               |
+| #1    | Per-type revision limit              |  ✓   |      —      |  —  | `mixed-types`     |
+| #2    | Admin overview                       |  ✓   |      —      |  —  | `heavy-site`      |
+| #3    | Bulk delete from overview            |  ✓   |      —      |  —  | `heavy-site`      |
+| #4    | Post list column                     |  ✓   |      —      |  —  | `normal-site`     |
+| #10   | Dashboard widget                     |  ✓   |      —      |  —  | `normal-site`     |
+| #11   | Per-post override                    |  ✓   |      —      |  —  | `mixed-types`     |
+| #13   | Tagging + protection                 |  ✓   |      —      |  —  | `tagged-site`     |
+| #14   | Dev fixtures CPTs                    |  ✓   |      —      |  —  | n/a               |
+| #15   | Content seeder (WP-CLI)              |  ✓   |      —      |  —  | n/a               |
+| #16   | Revision seeder (WP-CLI)             |  ✓   |      —      |  —  | n/a               |
 
 Integration and E2E rows are intentionally empty for v0.1.0 — the test
 infrastructure lands with v0.1.0; coverage fills in as the WP-PHPUnit

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,143 @@
+# Testing
+
+How Advanced Revisions is tested — coverage, fixtures, and the local runbook.
+
+## Philosophy
+
+Three layers, each with a clear remit:
+
+| Layer        | Location                               | What lives here                                         |
+|--------------|----------------------------------------|---------------------------------------------------------|
+| Unit         | `tests/Unit/`, `advanced-revisions-dev/tests/Unit/` | Pure logic, hook registration, SQL shape. Brain Monkey stubs WP. |
+| Integration  | `tests/Integration/`                   | Anything that touches `wp_posts`, taxonomies, meta, or WP hooks with real side effects. |
+| E2E          | `e2e/`                                 | Admin-screen interactions. Playwright against real WordPress. |
+
+Decision rule:
+
+- If it hits `wp_posts`, it goes in integration.
+- If it renders an admin screen a human clicks through, it goes in E2E.
+- Everything else goes in unit.
+
+## Running tests locally
+
+### Prerequisites
+
+```bash
+ddev start && ddev orchestrate
+composer install
+```
+
+### Unit tests
+
+```bash
+composer test:unit
+```
+
+Fast (< 1 second). No database. Uses Brain Monkey + the minimal `WP_Post` /
+`WP_Query` / `WP_User` stubs in `tests/wp-class-stubs.php`.
+
+### Integration tests
+
+```bash
+composer test:integration
+```
+
+Requires `WP_TESTS_DIR` to be set or `vendor/wp-phpunit/wp-phpunit` installed.
+The bootstrap auto-detects. See `CLAUDE.md` for the full setup.
+
+### E2E tests
+
+Activate the dev fixtures plugin and seed a scenario before running:
+
+```bash
+ddev wp plugin activate advanced-revisions-dev
+ddev wp ar-fixtures content --count=50 --seed=42
+ddev wp ar-fixtures revisions --distribution=normal --seed=42
+npm run test:e2e
+```
+
+## Coverage matrix
+
+One row per v0.1.0 feature. `✓` = covered, `—` = intentionally not covered at
+this layer.
+
+| Issue | Feature                              | Unit | Integration | E2E | Fixture scenario  |
+|-------|--------------------------------------|:----:|:-----------:|:---:|-------------------|
+| #1    | Per-type revision limit              |  ✓   |             |     | `mixed-types`     |
+| #2    | Admin overview                       |  ✓   |             |     | `heavy-site`      |
+| #3    | Bulk delete from overview            |  ✓   |             |     | `heavy-site`      |
+| #4    | Post list column                     |  ✓   |             |     | `normal-site`     |
+| #10   | Dashboard widget                     |  ✓   |             |     | `normal-site`     |
+| #11   | Per-post override                    |  ✓   |             |     | `mixed-types`     |
+| #13   | Tagging + protection                 |  ✓   |             |     | `tagged-site`     |
+| #14   | Dev fixtures CPTs                    |  ✓   |             |     | n/a               |
+| #15   | Content seeder (WP-CLI)              |  ✓   |             |     | n/a               |
+| #16   | Revision seeder (WP-CLI)             |  ✓   |             |     | n/a               |
+
+Integration and E2E rows are intentionally empty for v0.1.0 — the test
+infrastructure lands with v0.1.0; coverage fills in as the WP-PHPUnit
+runner and Playwright suites are wired up on CI. Later milestones should
+update this matrix as they land.
+
+## Fixture scenarios
+
+Named recipes for the `ar-fixtures` WP-CLI commands (from the dev plugin).
+Every scenario uses `--seed=42` by default for reproducibility.
+
+| Scenario         | Content command                                                                  | Revisions command                                                                   |
+|------------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `tiny-site`      | `ar-fixtures content --count=10`                                                 | `ar-fixtures revisions --distribution=sparse`                                       |
+| `normal-site`    | `ar-fixtures content --count=50`                                                 | `ar-fixtures revisions --distribution=normal`                                       |
+| `heavy-site`     | `ar-fixtures content --count=500`                                                | `ar-fixtures revisions --distribution=heavy`                                        |
+| `mixed-types`    | `ar-fixtures content --count=20 --post-types=ar_test_article,ar_test_product,ar_test_note` | `ar-fixtures revisions --distribution=normal`                              |
+| `orphan-heavy`   | `ar-fixtures content --count=50`                                                 | `ar-fixtures revisions --distribution=normal --orphan-count=200`                    |
+| `autosave-flood` | `ar-fixtures content --count=50`                                                 | `ar-fixtures revisions --distribution=normal --autosave-ratio=0.5`                  |
+| `age-spread`     | `ar-fixtures content --count=50 --date-spread=2190`                              | `ar-fixtures revisions --distribution=normal --spread-days=2190`                    |
+| `multi-author`   | `ar-fixtures content --count=50 --authors=10`                                    | `ar-fixtures revisions --distribution=normal`                                       |
+| `product-meta`   | `ar-fixtures content --count=30 --post-types=ar_test_product`                    | `ar-fixtures revisions --distribution=normal`                                       |
+| `tagged-site`    | `ar-fixtures content --count=30`                                                 | `ar-fixtures revisions --distribution=normal` + manual `wp_set_object_terms` calls  |
+| `extreme-perf`   | `ar-fixtures content --count=5000`                                               | `ar-fixtures revisions --distribution=extreme`                                      |
+
+Reset between scenarios:
+
+```bash
+ddev wp ar-fixtures reset-all
+```
+
+## E2E playbook
+
+For each Playwright spec:
+
+1. `global-setup.js` drops an MU-plugin stub into
+   `.ddev/wordpress/wp-content/mu-plugins/` that forces the dev plugin active.
+2. Per-suite `beforeAll`: `wp ar-fixtures reset-all` followed by the scenario
+   the spec needs.
+3. Auth handled by `e2e/auth.setup.js` (cached in `.auth/admin.json`).
+4. No per-test teardown — fixtures are per-run.
+
+## CI reference
+
+| Workflow             | Trigger          | Tests                                        |
+|----------------------|------------------|----------------------------------------------|
+| `ci.yml`             | PR, push to main | PHPCS, PHPStan, unit tests (PHP 8.2–8.4). Uploads coverage to Codecov. |
+| `integration.yml`    | PR, push to main | Integration tests, multisite matrix.         |
+| `e2e.yml`            | PR, push to main | Playwright + seeded scenarios.               |
+| `wp-beta.yml`        | Nightly          | Integration against WP beta / RC.            |
+| `pr-validation.yml`  | PR               | Conventional-commit + CHANGELOG entry checks.|
+
+## Gaps
+
+Tracked for follow-up, not scoped into v0.1.0:
+
+- Visual regression / screenshot diffing on the overview table
+- Load testing beyond 125k revisions
+- Accessibility testing via `@axe-core/playwright`
+- Integration-test wiring for the per-post override meta box and the
+  overview SQL queries
+
+## How to use this plan
+
+- Every feature PR updates the coverage matrix row for its issue.
+- A feature shipping without coverage at a given layer should mark `—`
+  explicitly, with a follow-up issue filed.
+- Never remove a row — closed issues still document what's covered.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,7 @@
     <exclude-pattern>.ddev/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>tests/wp-class-stubs.php</exclude-pattern>
 
     <arg name="extensions" value="php"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>tests/wp-class-stubs.php</exclude-pattern>
+    <exclude-pattern>tests/Fixtures/WpdbDouble.php</exclude-pattern>
 
     <arg name="extensions" value="php"/>
 
@@ -53,6 +54,8 @@
                 <element value="a"/>
                 <element value="b"/>
                 <element value="key"/>
+                <element value="cap"/>
+                <element value="cb"/>
                 <element value="min"/>
                 <element value="max"/>
                 <element value="num"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,11 +40,6 @@
         <exclude-pattern>tests/bootstrap.php</exclude-pattern>
     </rule>
 
-    <!-- Test fixtures legitimately need many-key arrays (options, mock payloads). -->
-    <rule ref="Apermo.DataStructures.ArrayComplexity.TooManyKeys">
-        <exclude-pattern>*/tests/*</exclude-pattern>
-    </rule>
-
     <rule ref="Apermo.NamingConventions.MinimumVariableNameLength">
         <properties>
             <property name="allowedShortNames" type="array">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -55,6 +55,8 @@
                 <element value="key"/>
                 <element value="min"/>
                 <element value="max"/>
+                <element value="num"/>
+                <element value="raw"/>
                 <element value="rng"/>
             </property>
         </properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -58,6 +58,7 @@
                 <element value="num"/>
                 <element value="raw"/>
                 <element value="rng"/>
+                <element value="url"/>
             </property>
         </properties>
     </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,5 +38,26 @@
         <exclude-pattern>tests/bootstrap.php</exclude-pattern>
     </rule>
 
+    <!-- Test fixtures legitimately need many-key arrays (options, mock payloads). -->
+    <rule ref="Apermo.DataStructures.ArrayComplexity.TooManyKeys">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Apermo.NamingConventions.MinimumVariableNameLength">
+        <properties>
+            <property name="allowedShortNames" type="array">
+                <element value="i"/>
+                <element value="id"/>
+                <element value="ids"/>
+                <element value="a"/>
+                <element value="b"/>
+                <element value="key"/>
+                <element value="min"/>
+                <element value="max"/>
+                <element value="rng"/>
+            </property>
+        </properties>
+    </rule>
+
     <config name="minimum_wp_version" value="6.4"/>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,3 +6,11 @@ parameters:
         - uninstall.php
         - advanced-revisions-dev/advanced-revisions-dev.php
         - advanced-revisions-dev/src
+    ignoreErrors:
+        # WP-CLI is only available when run under wp-cli. The dev plugin gates
+        # its registration behind defined('WP_CLI') so these calls are safe;
+        # no WP-CLI stub is installed because the production plugin never uses it.
+        -
+            message: '#Call to static method .+ on an unknown class WP_CLI\.#'
+            paths:
+                - advanced-revisions-dev/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,5 @@ parameters:
         - src
         - plugin.php
         - uninstall.php
+        - advanced-revisions-dev/advanced-revisions-dev.php
+        - advanced-revisions-dev/src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
+            <directory>advanced-revisions-dev/tests/Unit</directory>
         </testsuite>
         <testsuite name="Integration">
             <directory>tests/Integration</directory>

--- a/plugin.php
+++ b/plugin.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * Bootstraps the Advanced Revisions plugin.
+ *
  * Plugin Name: Advanced Revisions
  * Plugin URI:  https://github.com/apermo/advanced-revisions
  * Description: Advanced features for WordPress revisions: configurable limits per post type, an admin overview, and bulk deletion tools.

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -56,18 +56,29 @@ final class DashboardWidget {
 			return;
 		}
 
-		\printf(
-			'<p><strong>%1$s</strong> %2$s</p>',
-			esc_html( number_format_i18n( $stats['total'] ) ),
-			esc_html__( 'revisions stored site-wide.', 'advanced-revisions' ),
-		);
+		echo '<p>' . wp_kses(
+			\sprintf(
+				/* translators: %s: formatted revision count, wrapped in <strong> */
+				_n(
+					'<strong>%s</strong> revision stored site-wide.',
+					'<strong>%s</strong> revisions stored site-wide.',
+					$stats['total'],
+					'advanced-revisions',
+				),
+				esc_html( number_format_i18n( $stats['total'] ) ),
+			),
+			[ 'strong' => [] ],
+		) . '</p>';
 
 		if ( $stats['est_bytes'] > 0 ) {
-			\printf(
-				'<p>%1$s <strong>%2$s</strong></p>',
-				esc_html__( 'Estimated database footprint:', 'advanced-revisions' ),
-				esc_html( size_format( $stats['est_bytes'] ) ),
-			);
+			echo '<p>' . wp_kses(
+				\sprintf(
+					/* translators: %s: formatted database size, wrapped in <strong> */
+					__( 'Estimated database footprint: <strong>%s</strong>', 'advanced-revisions' ),
+					esc_html( size_format( $stats['est_bytes'] ) ),
+				),
+				[ 'strong' => [] ],
+			) . '</p>';
 		}
 
 		if ( $stats['top'] !== [] ) {

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisions\Admin;
 
+use wpdb;
+
 /**
  * Registers a dashboard widget that surfaces revision-bloat stats so admins
  * notice it without visiting a dedicated page.
@@ -123,6 +125,10 @@ final class DashboardWidget {
 	/**
 	 * Runs the aggregation queries.
 	 *
+	 * Every query excludes autosaves via the `post_name NOT LIKE '<parent>-autosave-%'`
+	 * pattern so the widget totals match what OverviewPage and PostListColumn
+	 * display — both of which already exclude autosaves.
+	 *
 	 * @return array{total:int, est_bytes:int, top:array<int, array{title:string, count:int}>}
 	 */
 	private static function compute(): array {
@@ -136,54 +142,88 @@ final class DashboardWidget {
 			];
 		}
 
+		return [
+			'total'     => self::compute_total( $wpdb ),
+			'est_bytes' => self::compute_est_bytes( $wpdb ),
+			'top'       => self::compute_top_posts( $wpdb ),
+		];
+	}
+
+	/**
+	 * Counts every non-autosave revision row site-wide.
+	 *
+	 * @param wpdb $wpdb WordPress database abstraction.
+	 */
+	private static function compute_total( wpdb $wpdb ): int {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
-		$total = (int) $wpdb->get_var(
+		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM %i WHERE post_type = 'revision'",
-				[ $wpdb->posts ],
+				"SELECT COUNT(*) FROM %i
+					WHERE post_type = 'revision'
+						AND post_name NOT LIKE CONCAT(post_parent, %s)",
+				[ $wpdb->posts, '-autosave-%' ],
 			),
 		);
+	}
 
+	/**
+	 * Estimates database footprint of stored revisions via SUM(LENGTH(post_content)).
+	 *
+	 * @param wpdb $wpdb WordPress database abstraction.
+	 */
+	private static function compute_est_bytes( wpdb $wpdb ): int {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
-		$est_bytes = (int) $wpdb->get_var(
+		return (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COALESCE(SUM(LENGTH(post_content)), 0) FROM %i WHERE post_type = 'revision'",
-				[ $wpdb->posts ],
+				"SELECT COALESCE(SUM(LENGTH(post_content)), 0) FROM %i
+					WHERE post_type = 'revision'
+						AND post_name NOT LIKE CONCAT(post_parent, %s)",
+				[ $wpdb->posts, '-autosave-%' ],
 			),
 		);
+	}
 
+	/**
+	 * Returns the top five parent posts ranked by non-autosave revision count.
+	 *
+	 * p.post_title is listed in GROUP BY so the query stays portable to MySQL
+	 * configurations with ONLY_FULL_GROUP_BY that don't honor
+	 * functional-dependency detection (MariaDB, managed hosts).
+	 *
+	 * @param wpdb $wpdb WordPress database abstraction.
+	 * @return array<int, array{title:string, count:int}>
+	 */
+	private static function compute_top_posts( wpdb $wpdb ): array {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT p.post_title, COUNT(r.ID) AS revision_count
 					FROM %i p
 					INNER JOIN %i r
-						ON r.post_parent = p.ID AND r.post_type = 'revision'
+						ON r.post_parent = p.ID
+						AND r.post_type = 'revision'
+						AND r.post_name NOT LIKE CONCAT(p.ID, %s)
 					WHERE p.post_type != 'revision'
-					GROUP BY p.ID
+					GROUP BY p.ID, p.post_title
 					ORDER BY revision_count DESC
 					LIMIT 5",
-				[ $wpdb->posts, $wpdb->posts ],
+				[ $wpdb->posts, $wpdb->posts, '-autosave-%' ],
 			),
 		);
 
 		$top_posts = [];
-		if ( \is_array( $rows ) ) {
-			foreach ( $rows as $row_data ) {
-				if ( ! isset( $row_data->post_title, $row_data->revision_count ) ) {
-					continue;
-				}
-				$top_posts[] = [
-					'title' => (string) $row_data->post_title,
-					'count' => (int) $row_data->revision_count,
-				];
-			}
+		if ( ! \is_array( $rows ) ) {
+			return $top_posts;
 		}
-
-		return [
-			'total'     => $total,
-			'est_bytes' => $est_bytes,
-			'top'       => $top_posts,
-		];
+		foreach ( $rows as $row_data ) {
+			if ( ! isset( $row_data->post_title, $row_data->revision_count ) ) {
+				continue;
+			}
+			$top_posts[] = [
+				'title' => (string) $row_data->post_title,
+				'count' => (int) $row_data->revision_count,
+			];
+		}
+		return $top_posts;
 	}
 }

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -50,7 +50,7 @@ final class DashboardWidget {
 		$stats = self::stats();
 
 		if ( $stats['total'] === 0 ) {
-			echo '<p>' . esc_html__( 'No stored revisions. You are clean.', 'advanced-revisions' ) . '</p>';
+			echo '<p>' . esc_html__( 'No stored revisions.', 'advanced-revisions' ) . '</p>';
 			return;
 		}
 

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -13,9 +13,9 @@ namespace Apermo\AdvancedRevisions\Admin;
  */
 final class DashboardWidget {
 
-	public const WIDGET_ID     = 'advanced_revisions_dashboard';
-	public const TRANSIENT_KEY = 'advanced_revisions_dashboard_stats';
-	public const CAPABILITY    = 'edit_others_posts';
+	public const WIDGET_ID           = 'advanced_revisions_dashboard';
+	public const TRANSIENT_KEY       = 'advanced_revisions_dashboard_stats';
+	public const REQUIRED_CAPABILITY = 'edit_others_posts';
 
 	/**
 	 * Transient TTL in seconds (1 hour).
@@ -33,7 +33,7 @@ final class DashboardWidget {
 	 * Adds the widget to the dashboard — gated by capability.
 	 */
 	public static function add_widget(): void {
-		if ( ! current_user_can( self::CAPABILITY ) ) {
+		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
 			return;
 		}
 		wp_add_dashboard_widget(

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -23,14 +23,14 @@ final class DashboardWidget {
 	public const TTL = 3600;
 
 	/**
-	 * Register on the dashboard setup hook.
+	 * Registers on the dashboard setup hook.
 	 */
 	public static function register(): void {
 		add_action( 'wp_dashboard_setup', [ self::class, 'add_widget' ] );
 	}
 
 	/**
-	 * Add the widget to the dashboard — gated by capability.
+	 * Adds the widget to the dashboard — gated by capability.
 	 */
 	public static function add_widget(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
@@ -44,7 +44,7 @@ final class DashboardWidget {
 	}
 
 	/**
-	 * Render the widget body.
+	 * Renders the widget body.
 	 */
 	public static function render(): void {
 		$stats = self::stats();
@@ -94,7 +94,7 @@ final class DashboardWidget {
 	}
 
 	/**
-	 * Return cached stats, computing + storing them if the transient is empty.
+	 * Returns cached stats, computing + storing them if the transient is empty.
 	 *
 	 * @return array{total:int, est_bytes:int, top:array<int, array{title:string, count:int}>}
 	 */
@@ -114,14 +114,14 @@ final class DashboardWidget {
 	}
 
 	/**
-	 * Flush the cached stats — call after a cleanup run so numbers refresh.
+	 * Flushes the cached stats — call after a cleanup run so numbers refresh.
 	 */
 	public static function flush(): void {
 		delete_transient( self::TRANSIENT_KEY );
 	}
 
 	/**
-	 * Run the aggregation queries.
+	 * Runs the aggregation queries.
 	 *
 	 * @return array{total:int, est_bytes:int, top:array<int, array{title:string, count:int}>}
 	 */

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -138,24 +138,33 @@ final class DashboardWidget {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
 		$total = (int) $wpdb->get_var(
-			"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'revision'",
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM %i WHERE post_type = 'revision'",
+				[ $wpdb->posts ],
+			),
 		);
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
 		$est_bytes = (int) $wpdb->get_var(
-			"SELECT COALESCE(SUM(LENGTH(post_content)), 0) FROM {$wpdb->posts} WHERE post_type = 'revision'",
+			$wpdb->prepare(
+				"SELECT COALESCE(SUM(LENGTH(post_content)), 0) FROM %i WHERE post_type = 'revision'",
+				[ $wpdb->posts ],
+			),
 		);
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
 		$rows = $wpdb->get_results(
-			"SELECT p.post_title, COUNT(r.ID) AS revision_count
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->posts} r
-					ON r.post_parent = p.ID AND r.post_type = 'revision'
-				WHERE p.post_type != 'revision'
-				GROUP BY p.ID
-				ORDER BY revision_count DESC
-				LIMIT 5",
+			$wpdb->prepare(
+				"SELECT p.post_title, COUNT(r.ID) AS revision_count
+					FROM %i p
+					INNER JOIN %i r
+						ON r.post_parent = p.ID AND r.post_type = 'revision'
+					WHERE p.post_type != 'revision'
+					GROUP BY p.ID
+					ORDER BY revision_count DESC
+					LIMIT 5",
+				[ $wpdb->posts, $wpdb->posts ],
+			),
 		);
 
 		$top_posts = [];

--- a/src/Admin/DashboardWidget.php
+++ b/src/Admin/DashboardWidget.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Admin;
+
+/**
+ * Registers a dashboard widget that surfaces revision-bloat stats so admins
+ * notice it without visiting a dedicated page.
+ *
+ * Stats are expensive to compute on sites with millions of revisions, so
+ * they're cached in a transient keyed on {@see self::TRANSIENT_KEY}.
+ */
+final class DashboardWidget {
+
+	public const WIDGET_ID     = 'advanced_revisions_dashboard';
+	public const TRANSIENT_KEY = 'advanced_revisions_dashboard_stats';
+	public const CAPABILITY    = 'edit_others_posts';
+
+	/**
+	 * Transient TTL in seconds (1 hour).
+	 */
+	public const TTL = 3600;
+
+	/**
+	 * Register on the dashboard setup hook.
+	 */
+	public static function register(): void {
+		add_action( 'wp_dashboard_setup', [ self::class, 'add_widget' ] );
+	}
+
+	/**
+	 * Add the widget to the dashboard — gated by capability.
+	 */
+	public static function add_widget(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			return;
+		}
+		wp_add_dashboard_widget(
+			self::WIDGET_ID,
+			__( 'Revisions', 'advanced-revisions' ),
+			[ self::class, 'render' ],
+		);
+	}
+
+	/**
+	 * Render the widget body.
+	 */
+	public static function render(): void {
+		$stats = self::stats();
+
+		if ( $stats['total'] === 0 ) {
+			echo '<p>' . esc_html__( 'No stored revisions. You are clean.', 'advanced-revisions' ) . '</p>';
+			return;
+		}
+
+		\printf(
+			'<p><strong>%1$s</strong> %2$s</p>',
+			esc_html( number_format_i18n( $stats['total'] ) ),
+			esc_html__( 'revisions stored site-wide.', 'advanced-revisions' ),
+		);
+
+		if ( $stats['est_bytes'] > 0 ) {
+			\printf(
+				'<p>%1$s <strong>%2$s</strong></p>',
+				esc_html__( 'Estimated database footprint:', 'advanced-revisions' ),
+				esc_html( size_format( $stats['est_bytes'] ) ),
+			);
+		}
+
+		if ( $stats['top'] !== [] ) {
+			echo '<p>' . esc_html__( 'Heaviest posts:', 'advanced-revisions' ) . '</p>';
+			echo '<ol>';
+			foreach ( $stats['top'] as $entry ) {
+				\printf(
+					'<li>%1$s <em>(%2$s)</em></li>',
+					esc_html( $entry['title'] ),
+					esc_html(
+						\sprintf(
+							/* translators: %d: revision count */
+							_n(
+								'%d revision',
+								'%d revisions',
+								$entry['count'],
+								'advanced-revisions',
+							),
+							$entry['count'],
+						),
+					),
+				);
+			}
+			echo '</ol>';
+		}
+	}
+
+	/**
+	 * Return cached stats, computing + storing them if the transient is empty.
+	 *
+	 * @return array{total:int, est_bytes:int, top:array<int, array{title:string, count:int}>}
+	 */
+	public static function stats(): array {
+		$cached = get_transient( self::TRANSIENT_KEY );
+		if ( \is_array( $cached ) && isset( $cached['total'], $cached['est_bytes'], $cached['top'] ) ) {
+			return [
+				'total'     => (int) $cached['total'],
+				'est_bytes' => (int) $cached['est_bytes'],
+				'top'       => \is_array( $cached['top'] ) ? $cached['top'] : [],
+			];
+		}
+
+		$fresh = self::compute();
+		set_transient( self::TRANSIENT_KEY, $fresh, self::TTL );
+		return $fresh;
+	}
+
+	/**
+	 * Flush the cached stats — call after a cleanup run so numbers refresh.
+	 */
+	public static function flush(): void {
+		delete_transient( self::TRANSIENT_KEY );
+	}
+
+	/**
+	 * Run the aggregation queries.
+	 *
+	 * @return array{total:int, est_bytes:int, top:array<int, array{title:string, count:int}>}
+	 */
+	private static function compute(): array {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return [
+				'total'     => 0,
+				'est_bytes' => 0,
+				'top'       => [],
+			];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
+		$total = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'revision'",
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
+		$est_bytes = (int) $wpdb->get_var(
+			"SELECT COALESCE(SUM(LENGTH(post_content)), 0) FROM {$wpdb->posts} WHERE post_type = 'revision'",
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; cached in transient.
+		$rows = $wpdb->get_results(
+			"SELECT p.post_title, COUNT(r.ID) AS revision_count
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->posts} r
+					ON r.post_parent = p.ID AND r.post_type = 'revision'
+				WHERE p.post_type != 'revision'
+				GROUP BY p.ID
+				ORDER BY revision_count DESC
+				LIMIT 5",
+		);
+
+		$top_posts = [];
+		if ( \is_array( $rows ) ) {
+			foreach ( $rows as $row_data ) {
+				if ( ! isset( $row_data->post_title, $row_data->revision_count ) ) {
+					continue;
+				}
+				$top_posts[] = [
+					'title' => (string) $row_data->post_title,
+					'count' => (int) $row_data->revision_count,
+				];
+			}
+		}
+
+		return [
+			'total'     => $total,
+			'est_bytes' => $est_bytes,
+			'top'       => $top_posts,
+		];
+	}
+}

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -173,7 +173,6 @@ final class OverviewPage {
 		echo esc_html__( 'Delete revisions for selected posts', 'advanced-revisions' );
 		echo '</button></p>';
 
-		// phpcs:ignore Apermo.WordPress.NoHardcodedTableNames.Found -- CSS class names on an HTML element, not SQL.
 		echo '<table class="wp-list-table widefat fixed striped">';
 		echo '<thead><tr>';
 		echo '<td class="manage-column column-cb check-column"><input type="checkbox" id="cb-select-all-1" /></td>';

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Admin;
+
+use Apermo\AdvancedRevisions\Revisions\RevisionDeleter;
+use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
+
+/**
+ * Tools → Revisions page. Lists posts with stored revisions and lets admins
+ * bulk-delete revisions across selected rows. Protected tags (from #13) are
+ * honored via {@see RevisionDeleter}.
+ */
+final class OverviewPage {
+
+	public const MENU_SLUG    = 'advanced-revisions-overview';
+	public const CAPABILITY   = 'edit_others_posts';
+	public const NONCE_ACTION = 'advanced_revisions_overview_bulk';
+	public const NONCE_NAME   = 'advanced_revisions_overview_nonce';
+	public const BULK_FIELD   = 'ar_bulk_delete';
+
+	/**
+	 * Wire the admin-menu and request-handling hooks.
+	 */
+	public static function register(): void {
+		add_action( 'admin_menu', [ self::class, 'add_page' ] );
+		add_action( 'admin_post_' . self::MENU_SLUG, [ self::class, 'handle_bulk_post' ] );
+	}
+
+	/**
+	 * Register the page under Tools.
+	 */
+	public static function add_page(): void {
+		add_management_page(
+			__( 'Revisions Overview', 'advanced-revisions' ),
+			__( 'Revisions', 'advanced-revisions' ),
+			self::CAPABILITY,
+			self::MENU_SLUG,
+			[ self::class, 'render' ],
+		);
+	}
+
+	/**
+	 * Render the overview table.
+	 */
+	public static function render(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			return;
+		}
+
+		$page       = self::current_page();
+		$repository = new RevisionRepository();
+		$rows       = $repository->paginated( RevisionRepository::DEFAULT_PER_PAGE, $page );
+		$total      = $repository->total_parents();
+
+		self::render_notices();
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Revisions Overview', 'advanced-revisions' ) . '</h1>';
+		echo '<p>';
+		echo esc_html__( 'Posts with stored revisions, heaviest first. Parent posts are never touched by bulk deletion.', 'advanced-revisions' );
+		echo '</p>';
+
+		if ( $rows === [] ) {
+			echo '<p>' . esc_html__( 'No posts currently have stored revisions.', 'advanced-revisions' ) . '</p>';
+			echo '</div>';
+			return;
+		}
+
+		self::render_form( $rows, $page, $total );
+
+		echo '</div>';
+	}
+
+	/**
+	 * Handle the bulk-delete POST submission from the overview form.
+	 */
+	public static function handle_bulk_post(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die( esc_html__( 'Insufficient permissions.', 'advanced-revisions' ) );
+		}
+
+		$nonce = isset( $_POST[ self::NONCE_NAME ] ) && \is_string( $_POST[ self::NONCE_NAME ] )
+			? sanitize_text_field( wp_unslash( $_POST[ self::NONCE_NAME ] ) )
+			: '';
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			wp_die( esc_html__( 'Invalid request.', 'advanced-revisions' ) );
+		}
+
+		$selected = self::selected_parent_ids();
+		if ( $selected === [] ) {
+			wp_safe_redirect( self::page_url( [ 'ar_bulk' => 'empty' ] ) );
+			return;
+		}
+
+		$deleter = new RevisionDeleter( new RevisionRepository() );
+		$result  = $deleter->delete_for_parents( $selected );
+
+		wp_safe_redirect(
+			self::page_url(
+				[
+					'ar_bulk'    => 'done',
+					'ar_deleted' => (string) $result['deleted'],
+					'ar_skipped' => (string) $result['skipped'],
+				],
+			),
+		);
+	}
+
+	/**
+	 * Parse 1-based page number from the query string, defaulting to 1.
+	 */
+	private static function current_page(): int {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only pagination parameter.
+		$paged = isset( $_GET['paged'] ) && \is_scalar( $_GET['paged'] )
+			? (int) $_GET['paged'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			: 1;
+		return \max( 1, $paged );
+	}
+
+	/**
+	 * Render completion notices after a bulk action redirects back.
+	 */
+	private static function render_notices(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- notice state parsed from query args after redirect.
+		if ( ! isset( $_GET['ar_bulk'] ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$state = \is_string( $_GET['ar_bulk'] ) ? sanitize_key( $_GET['ar_bulk'] ) : '';
+
+		if ( $state === 'empty' ) {
+			wp_admin_notice(
+				esc_html__( 'No posts were selected.', 'advanced-revisions' ),
+				[ 'type' => 'warning' ],
+			);
+			return;
+		}
+
+		if ( $state === 'done' ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$deleted = isset( $_GET['ar_deleted'] ) ? (int) $_GET['ar_deleted'] : 0;
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$skipped = isset( $_GET['ar_skipped'] ) ? (int) $_GET['ar_skipped'] : 0;
+
+			$message = \sprintf(
+				/* translators: 1: deleted count, 2: skipped count */
+				esc_html__( 'Deleted %1$d revisions. %2$d protected revisions were skipped.', 'advanced-revisions' ),
+				$deleted,
+				$skipped,
+			);
+			wp_admin_notice( $message, [ 'type' => 'success' ] );
+		}
+	}
+
+	/**
+	 * Render the overview form body.
+	 *
+	 * @param array<int, array<string, mixed>> $rows  Overview rows from RevisionRepository.
+	 * @param int                              $page  Current page (1-based).
+	 * @param int                              $total Total parent posts with revisions (for paginator).
+	 */
+	private static function render_form( array $rows, int $page, int $total ): void {
+		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+		echo '<input type="hidden" name="action" value="' . esc_attr( self::MENU_SLUG ) . '" />';
+		wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
+
+		echo '<p><button type="submit" class="button button-primary" name="' . esc_attr( self::BULK_FIELD ) . '" value="delete">';
+		echo esc_html__( 'Delete revisions for selected posts', 'advanced-revisions' );
+		echo '</button></p>';
+
+		// phpcs:ignore Apermo.WordPress.NoHardcodedTableNames.Found -- CSS class names on an HTML element, not SQL.
+		echo '<table class="wp-list-table widefat fixed striped">';
+		echo '<thead><tr>';
+		echo '<td class="manage-column column-cb check-column"><input type="checkbox" id="cb-select-all-1" /></td>';
+		echo '<th scope="col">' . esc_html__( 'Title', 'advanced-revisions' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Type', 'advanced-revisions' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Revisions', 'advanced-revisions' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Oldest', 'advanced-revisions' ) . '</th>';
+		echo '</tr></thead><tbody>';
+
+		foreach ( $rows as $row_data ) {
+			self::render_row( $row_data );
+		}
+
+		echo '</tbody></table>';
+
+		$total_pages = (int) \ceil( $total / RevisionRepository::DEFAULT_PER_PAGE );
+		if ( $total_pages > 1 ) {
+			self::render_pagination( $page, $total_pages );
+		}
+
+		echo '</form>';
+	}
+
+	/**
+	 * Render one row of the table.
+	 *
+	 * @param array<string, mixed> $row_data One row from RevisionRepository::paginated().
+	 */
+	private static function render_row( array $row_data ): void {
+		$edit_link = (string) get_edit_post_link( $row_data['id'] );
+
+		echo '<tr>';
+		\printf(
+			'<th class="check-column"><input type="checkbox" name="ar_parent_ids[]" value="%s" /></th>',
+			esc_attr( (string) $row_data['id'] ),
+		);
+
+		echo '<td>';
+		if ( $edit_link !== '' ) {
+			\printf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $edit_link ),
+				esc_html( $row_data['title'] !== '' ? $row_data['title'] : __( '(no title)', 'advanced-revisions' ) ),
+			);
+		} else {
+			echo esc_html( $row_data['title'] );
+		}
+		echo '</td>';
+
+		echo '<td>' . esc_html( $row_data['post_type'] ) . '</td>';
+		echo '<td>' . esc_html( (string) $row_data['revisions'] ) . '</td>';
+
+		$oldest = $row_data['oldest_gmt'] !== '' ? $row_data['oldest_gmt'] : '—';
+		echo '<td>' . esc_html( $oldest ) . '</td>';
+		echo '</tr>';
+	}
+
+	/**
+	 * Render prev/next pagination links.
+	 *
+	 * @param int $page        Current 1-based page number.
+	 * @param int $total_pages Total pages available.
+	 */
+	private static function render_pagination( int $page, int $total_pages ): void {
+		echo '<div class="tablenav"><div class="tablenav-pages">';
+		echo '<span class="displaying-num">' . esc_html(
+			\sprintf(
+				/* translators: 1: current page, 2: total pages */
+				__( 'Page %1$d of %2$d', 'advanced-revisions' ),
+				$page,
+				$total_pages,
+			),
+		) . '</span> ';
+
+		if ( $page > 1 ) {
+			echo '<a class="button" href="' . esc_url( self::page_url( [ 'paged' => (string) ( $page - 1 ) ] ) ) . '">' . esc_html__( '« Prev', 'advanced-revisions' ) . '</a> ';
+		}
+		if ( $page < $total_pages ) {
+			echo '<a class="button" href="' . esc_url( self::page_url( [ 'paged' => (string) ( $page + 1 ) ] ) ) . '">' . esc_html__( 'Next »', 'advanced-revisions' ) . '</a>';
+		}
+		echo '</div></div>';
+	}
+
+	/**
+	 * Build an absolute URL to the overview page with extra query args.
+	 *
+	 * @param array<string, string> $extra Additional query args.
+	 */
+	private static function page_url( array $extra = [] ): string {
+		$args = \array_merge( [ 'page' => self::MENU_SLUG ], $extra );
+		return add_query_arg( $args, admin_url( 'tools.php' ) );
+	}
+
+	/**
+	 * Parse the selected parent post IDs from $_POST['ar_parent_ids'].
+	 *
+	 * @return array<int, int>
+	 */
+	private static function selected_parent_ids(): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- caller (handle_bulk_post) verifies nonce before this runs.
+		if ( ! isset( $_POST['ar_parent_ids'] ) || ! \is_array( $_POST['ar_parent_ids'] ) ) {
+			return [];
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- values cast to int below; nonce verified by caller.
+		$raw_ids = $_POST['ar_parent_ids'];
+
+		$ids = [];
+		foreach ( $raw_ids as $raw ) {
+			if ( \is_scalar( $raw ) ) {
+				$ids[] = (int) $raw;
+			}
+		}
+		return \array_values( \array_filter( $ids, static fn( int $id ): bool => $id > 0 ) );
+	}
+}

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -184,7 +184,7 @@ final class OverviewPage {
 			return;
 		}
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$state = \is_string( $_GET['ar_bulk'] ) ? sanitize_key( $_GET['ar_bulk'] ) : '';
+		$state = \is_string( $_GET['ar_bulk'] ) ? sanitize_key( wp_unslash( $_GET['ar_bulk'] ) ) : '';
 
 		if ( $state === 'empty' ) {
 			wp_admin_notice(

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -97,6 +97,9 @@ final class OverviewPage {
 		$deleter = new RevisionDeleter( new RevisionRepository() );
 		$result  = $deleter->delete_for_parents( $selected );
 
+		// Invalidate aggregate caches so the dashboard widget reflects reality.
+		DashboardWidget::flush();
+
 		wp_safe_redirect(
 			self::page_url(
 				[

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -15,10 +15,35 @@ use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
 final class OverviewPage {
 
 	public const MENU_SLUG           = 'advanced-revisions-overview';
-	public const REQUIRED_CAPABILITY = 'edit_others_posts';
+	public const REQUIRED_CAPABILITY = 'delete_others_posts';
 	public const NONCE_ACTION        = 'advanced_revisions_overview_bulk';
 	public const NONCE_NAME          = 'advanced_revisions_overview_nonce';
 	public const BULK_FIELD          = 'ar_bulk_delete';
+
+	/**
+	 * Returns the capability required to view or act on the overview.
+	 *
+	 * Runs through the `advanced_revisions_bulk_delete_capability` filter so
+	 * sites with custom role maps can widen or narrow access without editing
+	 * the plugin. Per-parent authorization is additionally enforced in
+	 * handle_bulk_post() via current_user_can('edit_post', $parent_id).
+	 */
+	public static function required_capability(): string {
+		/**
+		 * Filters the capability required to view or act on the Tools → Revisions
+		 * overview page. Per-parent authorization still runs via
+		 * current_user_can('edit_post', $parent_id) inside handle_bulk_post().
+		 *
+		 * @param string $capability Default: 'delete_others_posts'.
+		 * @return string Capability string; falsy returns fall back to the default.
+		 */
+		$cap = apply_filters(
+			'advanced_revisions_bulk_delete_capability',
+			self::REQUIRED_CAPABILITY,
+		);
+		// @phpstan-ignore-next-line function.alreadyNarrowedType -- apply_filters can return any value via third-party hooks despite the declared return type.
+		return \is_string( $cap ) && $cap !== '' ? $cap : self::REQUIRED_CAPABILITY;
+	}
 
 	/**
 	 * Wires the admin-menu and request-handling hooks.
@@ -35,7 +60,7 @@ final class OverviewPage {
 		add_management_page(
 			__( 'Revisions Overview', 'advanced-revisions' ),
 			__( 'Revisions', 'advanced-revisions' ),
-			self::REQUIRED_CAPABILITY,
+			self::required_capability(),
 			self::MENU_SLUG,
 			[ self::class, 'render' ],
 		);
@@ -45,7 +70,7 @@ final class OverviewPage {
 	 * Renders the overview table.
 	 */
 	public static function render(): void {
-		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
+		if ( ! current_user_can( self::required_capability() ) ) {
 			return;
 		}
 
@@ -77,7 +102,7 @@ final class OverviewPage {
 	 * Handles the bulk-delete POST submission from the overview form.
 	 */
 	public static function handle_bulk_post(): void {
-		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
+		if ( ! current_user_can( self::required_capability() ) ) {
 			wp_die( esc_html__( 'Insufficient permissions.', 'advanced-revisions' ) );
 		}
 
@@ -91,11 +116,37 @@ final class OverviewPage {
 		$selected = self::selected_parent_ids();
 		if ( $selected === [] ) {
 			wp_safe_redirect( self::page_url( [ 'ar_bulk' => 'empty' ] ) );
-			return;
+			exit();
+		}
+
+		// Per-parent authorization. A user who can reach this screen still
+		// shouldn't be able to delete revisions for parents they can't edit
+		// (custom caps, post-type-specific roles). Unauthorized IDs drop out
+		// and are counted separately in the completion notice.
+		$authorized = [];
+		$denied     = 0;
+		foreach ( $selected as $parent_id ) {
+			if ( current_user_can( 'edit_post', $parent_id ) ) {
+				$authorized[] = $parent_id;
+				continue;
+			}
+			$denied++;
+		}
+
+		if ( $authorized === [] ) {
+			wp_safe_redirect(
+				self::page_url(
+					[
+						'ar_bulk'   => 'done',
+						'ar_denied' => (string) $denied,
+					],
+				),
+			);
+			exit();
 		}
 
 		$deleter = new RevisionDeleter( new RevisionRepository() );
-		$result  = $deleter->delete_for_parents( $selected );
+		$result  = $deleter->delete_for_parents( $authorized );
 
 		// Invalidate aggregate caches so the dashboard widget reflects reality.
 		DashboardWidget::flush();
@@ -106,9 +157,11 @@ final class OverviewPage {
 					'ar_bulk'    => 'done',
 					'ar_deleted' => (string) $result['deleted'],
 					'ar_skipped' => (string) $result['skipped'],
+					'ar_denied'  => (string) $denied,
 				],
 			),
 		);
+		exit();
 	}
 
 	/**
@@ -142,19 +195,51 @@ final class OverviewPage {
 		}
 
 		if ( $state === 'done' ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$deleted = isset( $_GET['ar_deleted'] ) ? (int) $_GET['ar_deleted'] : 0;
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$skipped = isset( $_GET['ar_skipped'] ) ? (int) $_GET['ar_skipped'] : 0;
+			wp_admin_notice(
+				self::done_notice_message(),
+				[ 'type' => 'success' ],
+			);
+		}
+	}
 
-			$message = \sprintf(
-				/* translators: 1: deleted count, 2: skipped count */
-				esc_html__( 'Deleted %1$d revisions. %2$d protected revisions were skipped.', 'advanced-revisions' ),
+	/**
+	 * Assembles the done-state notice message from the redirect's query args.
+	 *
+	 * Reports deletion count plus, when non-zero, the number of revisions
+	 * skipped due to tag-based protection and the number of posts the current
+	 * user wasn't authorized to edit. Integer-cast input is safe to interpolate
+	 * into the translated sentence; no raw strings reach the output.
+	 */
+	private static function done_notice_message(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- parsed from redirect query args.
+		$deleted = isset( $_GET['ar_deleted'] ) ? (int) $_GET['ar_deleted'] : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$skipped = isset( $_GET['ar_skipped'] ) ? (int) $_GET['ar_skipped'] : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$denied = isset( $_GET['ar_denied'] ) ? (int) $_GET['ar_denied'] : 0;
+
+		$parts = [
+			\sprintf(
+				/* translators: %d: number of deleted revisions */
+				esc_html__( 'Deleted %d revisions.', 'advanced-revisions' ),
 				$deleted,
+			),
+		];
+		if ( $skipped > 0 ) {
+			$parts[] = \sprintf(
+				/* translators: %d: number of protected revisions that were skipped */
+				esc_html__( '%d protected revisions were skipped.', 'advanced-revisions' ),
 				$skipped,
 			);
-			wp_admin_notice( $message, [ 'type' => 'success' ] );
 		}
+		if ( $denied > 0 ) {
+			$parts[] = \sprintf(
+				/* translators: %d: number of posts the user lacked permission to edit */
+				esc_html__( '%d posts were skipped because you lack permission to edit them.', 'advanced-revisions' ),
+				$denied,
+			);
+		}
+		return \implode( ' ', $parts );
 	}
 
 	/**

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -14,11 +14,11 @@ use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
  */
 final class OverviewPage {
 
-	public const MENU_SLUG    = 'advanced-revisions-overview';
-	public const CAPABILITY   = 'edit_others_posts';
-	public const NONCE_ACTION = 'advanced_revisions_overview_bulk';
-	public const NONCE_NAME   = 'advanced_revisions_overview_nonce';
-	public const BULK_FIELD   = 'ar_bulk_delete';
+	public const MENU_SLUG           = 'advanced-revisions-overview';
+	public const REQUIRED_CAPABILITY = 'edit_others_posts';
+	public const NONCE_ACTION        = 'advanced_revisions_overview_bulk';
+	public const NONCE_NAME          = 'advanced_revisions_overview_nonce';
+	public const BULK_FIELD          = 'ar_bulk_delete';
 
 	/**
 	 * Wires the admin-menu and request-handling hooks.
@@ -35,7 +35,7 @@ final class OverviewPage {
 		add_management_page(
 			__( 'Revisions Overview', 'advanced-revisions' ),
 			__( 'Revisions', 'advanced-revisions' ),
-			self::CAPABILITY,
+			self::REQUIRED_CAPABILITY,
 			self::MENU_SLUG,
 			[ self::class, 'render' ],
 		);
@@ -45,7 +45,7 @@ final class OverviewPage {
 	 * Renders the overview table.
 	 */
 	public static function render(): void {
-		if ( ! current_user_can( self::CAPABILITY ) ) {
+		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
 			return;
 		}
 
@@ -77,7 +77,7 @@ final class OverviewPage {
 	 * Handles the bulk-delete POST submission from the overview form.
 	 */
 	public static function handle_bulk_post(): void {
-		if ( ! current_user_can( self::CAPABILITY ) ) {
+		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
 			wp_die( esc_html__( 'Insufficient permissions.', 'advanced-revisions' ) );
 		}
 

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -21,7 +21,7 @@ final class OverviewPage {
 	public const BULK_FIELD   = 'ar_bulk_delete';
 
 	/**
-	 * Wire the admin-menu and request-handling hooks.
+	 * Wires the admin-menu and request-handling hooks.
 	 */
 	public static function register(): void {
 		add_action( 'admin_menu', [ self::class, 'add_page' ] );
@@ -29,7 +29,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Register the page under Tools.
+	 * Registers the page under Tools.
 	 */
 	public static function add_page(): void {
 		add_management_page(
@@ -42,7 +42,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Render the overview table.
+	 * Renders the overview table.
 	 */
 	public static function render(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
@@ -74,7 +74,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Handle the bulk-delete POST submission from the overview form.
+	 * Handles the bulk-delete POST submission from the overview form.
 	 */
 	public static function handle_bulk_post(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {
@@ -112,7 +112,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Parse 1-based page number from the query string, defaulting to 1.
+	 * Parses 1-based page number from the query string, defaulting to 1.
 	 */
 	private static function current_page(): int {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only pagination parameter.
@@ -123,7 +123,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Render completion notices after a bulk action redirects back.
+	 * Renders completion notices after a bulk action redirects back.
 	 */
 	private static function render_notices(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- notice state parsed from query args after redirect.
@@ -158,7 +158,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Render the overview form body.
+	 * Renders the overview form body.
 	 *
 	 * @param array<int, array<string, mixed>> $rows  Overview rows from RevisionRepository.
 	 * @param int                              $page  Current page (1-based).
@@ -198,7 +198,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Render one row of the table.
+	 * Renders one row of the table.
 	 *
 	 * @param array<string, mixed> $row_data One row from RevisionRepository::paginated().
 	 */
@@ -232,7 +232,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Render prev/next pagination links.
+	 * Renders prev/next pagination links.
 	 *
 	 * @param int $page        Current 1-based page number.
 	 * @param int $total_pages Total pages available.
@@ -258,7 +258,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Build an absolute URL to the overview page with extra query args.
+	 * Builds an absolute URL to the overview page with extra query args.
 	 *
 	 * @param array<string, string> $extra Additional query args.
 	 */
@@ -268,7 +268,7 @@ final class OverviewPage {
 	}
 
 	/**
-	 * Parse the selected parent post IDs from $_POST['ar_parent_ids'].
+	 * Parses the selected parent post IDs from $_POST['ar_parent_ids'].
 	 *
 	 * @return array<int, int>
 	 */

--- a/src/Admin/OverviewPage.php
+++ b/src/Admin/OverviewPage.php
@@ -260,7 +260,10 @@ final class OverviewPage {
 
 		echo '<table class="wp-list-table widefat fixed striped">';
 		echo '<thead><tr>';
-		echo '<td class="manage-column column-cb check-column"><input type="checkbox" id="cb-select-all-1" /></td>';
+		echo '<td class="manage-column column-cb check-column">';
+		echo '<label class="screen-reader-text" for="cb-select-all-1">' . esc_html__( 'Select all posts', 'advanced-revisions' ) . '</label>';
+		echo '<input type="checkbox" id="cb-select-all-1" />';
+		echo '</td>';
 		echo '<th scope="col">' . esc_html__( 'Title', 'advanced-revisions' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Type', 'advanced-revisions' ) . '</th>';
 		echo '<th scope="col">' . esc_html__( 'Revisions', 'advanced-revisions' ) . '</th>';
@@ -289,9 +292,19 @@ final class OverviewPage {
 	private static function render_row( array $row_data ): void {
 		$edit_link = (string) get_edit_post_link( $row_data['id'] );
 
+		$checkbox_id = 'cb-select-' . (int) $row_data['id'];
+
 		echo '<tr>';
 		\printf(
-			'<th class="check-column"><input type="checkbox" name="ar_parent_ids[]" value="%s" /></th>',
+			'<th class="check-column"><label class="screen-reader-text" for="%1$s">%2$s</label><input type="checkbox" id="%1$s" name="ar_parent_ids[]" value="%3$s" /></th>',
+			esc_attr( $checkbox_id ),
+			esc_html(
+				\sprintf(
+					/* translators: %s: post title */
+					__( 'Select %s', 'advanced-revisions' ),
+					$row_data['title'] !== '' ? $row_data['title'] : __( '(no title)', 'advanced-revisions' ),
+				),
+			),
 			esc_attr( (string) $row_data['id'] ),
 		);
 

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -184,25 +184,40 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Load a revision-count map keyed by parent post ID for all posts on the
-	 * Current admin list screen, via a single SQL query.
+	 * Load a revision-count map keyed by parent post ID.
+	 *
+	 * Scoped to the post IDs on the current admin list screen (via the main
+	 * $wp_query) so we don't aggregate across every revision on the site. If
+	 * no screen-scope is available, returns an empty map — the column will
+	 * render "—" until a screen-scoped query is available.
 	 *
 	 * @return array<int, int>
 	 */
 	private static function load_counts(): array {
-		global $wpdb;
+		global $wpdb, $wp_query;
 		if ( ! isset( $wpdb ) ) {
 			return [];
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; caching is the per-request static map above.
-		$rows = $wpdb->get_results(
+		$post_ids = self::current_screen_post_ids( $wp_query ?? null );
+		if ( $post_ids === [] ) {
+			return [];
+		}
+
+		$placeholders = \implode( ',', \array_fill( 0, \count( $post_ids ), '%d' ) );
+		$query        = \sprintf(
 			"SELECT post_parent, COUNT(*) AS revision_count
 				FROM {$wpdb->posts}
 				WHERE post_type = 'revision'
-					AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%')
+					AND post_parent IN (%s)
+					AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%%')
 				GROUP BY post_parent",
+			$placeholders,
 		);
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- scoped to trusted int IDs from the main query.
+		$rows = $wpdb->get_results( $wpdb->prepare( $query, ...$post_ids ) );
+		// phpcs:enable
 
 		$counts = [];
 		if ( ! \is_array( $rows ) ) {
@@ -216,6 +231,28 @@ final class PostListColumn {
 			$counts[ (int) $row_data->post_parent ] = (int) $row_data->revision_count;
 		}
 		return $counts;
+	}
+
+	/**
+	 * Extract post IDs from the main $wp_query's current page of results.
+	 *
+	 * @param mixed $wp_query Global $wp_query reference (WP_Query or null).
+	 * @return array<int, int>
+	 */
+	private static function current_screen_post_ids( mixed $wp_query ): array {
+		if ( ! \is_object( $wp_query ) || ! isset( $wp_query->posts ) || ! \is_array( $wp_query->posts ) ) {
+			return [];
+		}
+
+		$ids = [];
+		foreach ( $wp_query->posts as $post ) {
+			if ( \is_object( $post ) && isset( $post->ID ) ) {
+				$ids[] = (int) $post->ID;
+			} elseif ( \is_int( $post ) ) {
+				$ids[] = $post;
+			}
+		}
+		return $ids;
 	}
 
 	/**

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -10,9 +10,11 @@ use WP_Post;
  * Adds a "Revisions" column + "Manage revisions" row action to the Posts/Pages
  * list tables for every post type that supports revisions.
  *
- * Aggregation strategy: on the first render, we batch-count revisions for all
- * parent IDs visible on the current screen in a single SQL query, cached in
- * a static map. Subsequent render calls for the same page are O(1).
+ * Aggregation strategy: on the first render, a single SQL query batch-fetches
+ * the revision count AND the latest revision ID for every parent visible on
+ * the current screen, cached in two static maps. Subsequent render calls for
+ * the same page — including the per-row compare_url() calls — are O(1) lookups
+ * instead of N+1 wp_get_post_revisions() queries.
  */
 final class PostListColumn {
 
@@ -24,6 +26,15 @@ final class PostListColumn {
 	 * @var array<int, int>|null
 	 */
 	private static ?array $counts = null;
+
+	/**
+	 * Cached latest revision ID keyed by parent post ID for the current request.
+	 * Populated alongside $counts by load_aggregates(); queried by compare_url()
+	 * to avoid a wp_get_post_revisions() call per rendered row.
+	 *
+	 * @var array<int, int>|null
+	 */
+	private static ?array $latest_ids = null;
 
 	/**
 	 * Registers filters for every revision-supporting public post type.
@@ -141,9 +152,23 @@ final class PostListColumn {
 	/**
 	 * Returns the ID of the latest revision for a post, or null if none.
 	 *
+	 * Hits the per-request $latest_ids cache (populated by load_aggregates() for
+	 * every post on the current screen) so a list-table render is one SQL query
+	 * for every column + row-action URL combined, not one per row.
+	 *
+	 * Falls back to wp_get_post_revisions() for post_ids not on the current
+	 * screen (external callers: CLI, bulk-action previews).
+	 *
 	 * @param int $post_id Parent post ID.
 	 */
 	private static function latest_revision_id( int $post_id ): ?int {
+		if ( self::$latest_ids === null ) {
+			self::$counts = self::load_aggregates();
+		}
+		if ( isset( self::$latest_ids[ $post_id ] ) ) {
+			return self::$latest_ids[ $post_id ];
+		}
+
 		$revisions = wp_get_post_revisions(
 			$post_id,
 			[
@@ -171,7 +196,7 @@ final class PostListColumn {
 	 */
 	public static function count_for( int $post_id ): int {
 		if ( self::$counts === null ) {
-			self::$counts = self::load_counts();
+			self::$counts = self::load_aggregates();
 		}
 		return self::$counts[ $post_id ] ?? 0;
 	}
@@ -180,21 +205,30 @@ final class PostListColumn {
 	 * Resets the per-request cache. Intended for tests.
 	 */
 	public static function reset_cache(): void {
-		self::$counts = null;
+		self::$counts     = null;
+		self::$latest_ids = null;
 	}
 
 	/**
-	 * Loads a revision-count map keyed by parent post ID.
+	 * Loads the revision-count map keyed by parent post ID, and populates the
+	 * parallel $latest_ids cache in the same round-trip.
 	 *
 	 * Scoped to the post IDs on the current admin list screen (via the main
 	 * $wp_query) so we don't aggregate across every revision on the site. If
 	 * no screen-scope is available, returns an empty map — the column will
 	 * render "—" until a screen-scoped query is available.
 	 *
+	 * MAX(ID) approximates "latest revision" under the assumption that
+	 * revision rows are inserted monotonically (WP core always does). In the
+	 * edge case of post restoration reconciling older rows, this may not be
+	 * the strictly-latest-by-date row; the link still goes to a valid revision
+	 * for the same parent, which is the only correctness requirement.
+	 *
 	 * @return array<int, int>
 	 */
-	private static function load_counts(): array {
+	private static function load_aggregates(): array {
 		global $wpdb, $wp_query;
+		self::$latest_ids = [];
 		if ( ! isset( $wpdb ) ) {
 			return [];
 		}
@@ -211,7 +245,7 @@ final class PostListColumn {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- {$placeholders} is a fixed %d repeater; merged args feed wpdb::prepare.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT post_parent, COUNT(*) AS revision_count
+				"SELECT post_parent, COUNT(*) AS revision_count, MAX(ID) AS latest_id
 					FROM %i
 					WHERE post_type = 'revision'
 						AND post_parent IN ({$placeholders})
@@ -232,10 +266,12 @@ final class PostListColumn {
 		}
 
 		foreach ( $rows as $row_data ) {
-			if ( ! isset( $row_data->post_parent, $row_data->revision_count ) ) {
+			if ( ! isset( $row_data->post_parent, $row_data->revision_count, $row_data->latest_id ) ) {
 				continue;
 			}
-			$counts[ (int) $row_data->post_parent ] = (int) $row_data->revision_count;
+			$parent_id                      = (int) $row_data->post_parent;
+			$counts[ $parent_id ]           = (int) $row_data->revision_count;
+			self::$latest_ids[ $parent_id ] = (int) $row_data->latest_id;
 		}
 		return $counts;
 	}

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -204,19 +204,26 @@ final class PostListColumn {
 			return [];
 		}
 
-		$placeholders = \implode( ',', \array_fill( 0, \count( $post_ids ), '%d' ) );
-		$query        = \sprintf(
-			"SELECT post_parent, COUNT(*) AS revision_count
-				FROM {$wpdb->posts}
-				WHERE post_type = 'revision'
-					AND post_parent IN (%s)
-					AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%%')
-				GROUP BY post_parent",
-			$placeholders,
-		);
+		$placeholders = \implode( ', ', \array_fill( 0, \count( $post_ids ), '%d' ) );
+		// Literal LIKE pattern; no user input to escape.
+		$autosave_like = '-autosave-%';
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- scoped to trusted int IDs from the main query.
-		$rows = $wpdb->get_results( $wpdb->prepare( $query, ...$post_ids ) );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- {$placeholders} is a fixed %d repeater; merged args feed wpdb::prepare.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_parent, COUNT(*) AS revision_count
+					FROM %i
+					WHERE post_type = 'revision'
+						AND post_parent IN ({$placeholders})
+						AND post_name NOT LIKE CONCAT(post_parent, %s)
+					GROUP BY post_parent",
+				\array_merge(
+					[ $wpdb->posts ],
+					$post_ids,
+					[ $autosave_like ],
+				),
+			),
+		);
 		// phpcs:enable
 
 		$counts = [];

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -117,17 +117,51 @@ final class PostListColumn {
 	/**
 	 * URL of the native revision compare screen for a post.
 	 *
+	 * Note: revision.php expects a revision ID (post_type=revision), not the
+	 * parent post ID. If we can find the latest revision, link directly to it;
+	 * otherwise fall back to the post edit screen which has a native "Browse"
+	 * link to revisions.
+	 *
 	 * @param int $post_id Parent post ID.
 	 */
 	public static function compare_url( int $post_id ): string {
-		$base_url = admin_url( 'revision.php' );
-		return add_query_arg(
+		$latest_revision = self::latest_revision_id( $post_id );
+
+		if ( $latest_revision !== null ) {
+			return add_query_arg(
+				[ 'revision' => $latest_revision ],
+				admin_url( 'revision.php' ),
+			);
+		}
+
+		$edit = get_edit_post_link( $post_id, 'raw' );
+		return \is_string( $edit ) && $edit !== '' ? $edit : admin_url();
+	}
+
+	/**
+	 * Return the ID of the latest revision for a post, or null if none.
+	 *
+	 * @param int $post_id Parent post ID.
+	 */
+	private static function latest_revision_id( int $post_id ): ?int {
+		$revisions = wp_get_post_revisions(
+			$post_id,
 			[
-				'from' => $post_id,
-				'to'   => $post_id,
+				'numberposts' => 1,
+				'order'       => 'DESC',
+				'orderby'     => 'post_date_gmt',
 			],
-			$base_url,
 		);
+
+		if ( $revisions === [] ) {
+			return null;
+		}
+
+		$first = \reset( $revisions );
+		if ( ! $first instanceof WP_Post ) {
+			return null;
+		}
+		return $first->ID;
 	}
 
 	/**

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Admin;
+
+use WP_Post;
+
+/**
+ * Adds a "Revisions" column + "Manage revisions" row action to the Posts/Pages
+ * list tables for every post type that supports revisions.
+ *
+ * Aggregation strategy: on the first render, we batch-count revisions for all
+ * parent IDs visible on the current screen in a single SQL query, cached in
+ * a static map. Subsequent render calls for the same page are O(1).
+ */
+final class PostListColumn {
+
+	public const COLUMN_KEY = 'advanced_revisions_count';
+
+	/**
+	 * Cached revision counts keyed by parent post ID for the current request.
+	 *
+	 * @var array<int, int>|null
+	 */
+	private static ?array $counts = null;
+
+	/**
+	 * Register filters for every revision-supporting public post type.
+	 */
+	public static function register(): void {
+		add_action( 'admin_init', [ self::class, 'hook_post_type_filters' ] );
+	}
+
+	/**
+	 * Attach column + row-action filters to every revision-enabled post type.
+	 */
+	public static function hook_post_type_filters(): void {
+		foreach ( self::supported_post_types() as $post_type ) {
+			add_filter( "manage_{$post_type}_posts_columns", [ self::class, 'add_column' ] );
+			add_action( "manage_{$post_type}_posts_custom_column", [ self::class, 'render_column' ], 10, 2 );
+		}
+
+		add_filter( 'post_row_actions', [ self::class, 'add_row_action' ], 10, 2 );
+		add_filter( 'page_row_actions', [ self::class, 'add_row_action' ], 10, 2 );
+	}
+
+	/**
+	 * Insert our column after the date column (or at the end if date is absent).
+	 *
+	 * @param array<string, string> $columns Existing columns map.
+	 * @return array<string, string>
+	 */
+	public static function add_column( array $columns ): array {
+		$label = __( 'Revisions', 'advanced-revisions' );
+
+		if ( ! \array_key_exists( 'date', $columns ) ) {
+			$columns[ self::COLUMN_KEY ] = $label;
+			return $columns;
+		}
+
+		$rebuilt = [];
+		foreach ( $columns as $key => $value ) {
+			$rebuilt[ $key ] = $value;
+			if ( $key === 'date' ) {
+				$rebuilt[ self::COLUMN_KEY ] = $label;
+			}
+		}
+		return $rebuilt;
+	}
+
+	/**
+	 * Print the revision count for a given post.
+	 *
+	 * @param string $column  Current column slug being rendered.
+	 * @param int    $post_id Parent post ID for this row.
+	 */
+	public static function render_column( string $column, int $post_id ): void {
+		if ( $column !== self::COLUMN_KEY ) {
+			return;
+		}
+
+		$count = self::count_for( $post_id );
+		if ( $count === 0 ) {
+			echo '<span aria-hidden="true">—</span>';
+			return;
+		}
+
+		\printf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( self::compare_url( $post_id ) ),
+			esc_html( (string) $count ),
+		);
+	}
+
+	/**
+	 * Append a "Manage revisions" row action linking to the native compare screen.
+	 *
+	 * @param array<string, string> $actions Existing row actions.
+	 * @param \WP_Post              $post    Post being rendered.
+	 * @return array<string, string>
+	 */
+	public static function add_row_action( array $actions, WP_Post $post ): array {
+		if ( self::count_for( $post->ID ) === 0 ) {
+			return $actions;
+		}
+
+		$actions['advanced_revisions_manage'] = \sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( self::compare_url( $post->ID ) ),
+			esc_html__( 'Manage revisions', 'advanced-revisions' ),
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * URL of the native revision compare screen for a post.
+	 *
+	 * @param int $post_id Parent post ID.
+	 */
+	public static function compare_url( int $post_id ): string {
+		$base_url = admin_url( 'revision.php' );
+		return add_query_arg(
+			[
+				'from' => $post_id,
+				'to'   => $post_id,
+			],
+			$base_url,
+		);
+	}
+
+	/**
+	 * Return the revision count for a single post, hitting the batch cache.
+	 *
+	 * @param int $post_id Parent post ID.
+	 */
+	public static function count_for( int $post_id ): int {
+		if ( self::$counts === null ) {
+			self::$counts = self::load_counts();
+		}
+		return self::$counts[ $post_id ] ?? 0;
+	}
+
+	/**
+	 * Reset the per-request cache. Intended for tests.
+	 */
+	public static function reset_cache(): void {
+		self::$counts = null;
+	}
+
+	/**
+	 * Load a revision-count map keyed by parent post ID for all posts on the
+	 * Current admin list screen, via a single SQL query.
+	 *
+	 * @return array<int, int>
+	 */
+	private static function load_counts(): array {
+		global $wpdb;
+		if ( ! isset( $wpdb ) ) {
+			return [];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation query; caching is the per-request static map above.
+		$rows = $wpdb->get_results(
+			"SELECT post_parent, COUNT(*) AS revision_count
+				FROM {$wpdb->posts}
+				WHERE post_type = 'revision'
+					AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%')
+				GROUP BY post_parent",
+		);
+
+		$counts = [];
+		if ( ! \is_array( $rows ) ) {
+			return $counts;
+		}
+
+		foreach ( $rows as $row_data ) {
+			if ( ! isset( $row_data->post_parent, $row_data->revision_count ) ) {
+				continue;
+			}
+			$counts[ (int) $row_data->post_parent ] = (int) $row_data->revision_count;
+		}
+		return $counts;
+	}
+
+	/**
+	 * Public post types that support revisions.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function supported_post_types(): array {
+		$types = [];
+		foreach ( get_post_types( [ 'public' => true ], 'names' ) as $post_type ) {
+			if ( post_type_supports( $post_type, 'revisions' ) ) {
+				$types[] = $post_type;
+			}
+		}
+		return $types;
+	}
+}

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisions\Admin;
 
 use WP_Post;
+use WP_Query;
 
 /**
  * Adds a "Revisions" column + "Manage revisions" row action to the Posts/Pages
@@ -279,18 +280,18 @@ final class PostListColumn {
 	/**
 	 * Extracts post IDs from the main $wp_query's current page of results.
 	 *
-	 * @param mixed $wp_query Global $wp_query reference (WP_Query or null).
+	 * @param WP_Query|null $wp_query Global $wp_query reference, or null when unavailable.
 	 * @return array<int, int>
 	 */
-	private static function current_screen_post_ids( mixed $wp_query ): array {
-		if ( ! \is_object( $wp_query ) || ! isset( $wp_query->posts ) || ! \is_array( $wp_query->posts ) ) {
+	private static function current_screen_post_ids( ?WP_Query $wp_query ): array {
+		if ( ! $wp_query instanceof WP_Query ) {
 			return [];
 		}
 
 		$ids = [];
 		foreach ( $wp_query->posts as $post ) {
-			if ( \is_object( $post ) && isset( $post->ID ) ) {
-				$ids[] = (int) $post->ID;
+			if ( $post instanceof WP_Post ) {
+				$ids[] = $post->ID;
 			} elseif ( \is_int( $post ) ) {
 				$ids[] = $post;
 			}

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -26,14 +26,14 @@ final class PostListColumn {
 	private static ?array $counts = null;
 
 	/**
-	 * Register filters for every revision-supporting public post type.
+	 * Registers filters for every revision-supporting public post type.
 	 */
 	public static function register(): void {
 		add_action( 'admin_init', [ self::class, 'hook_post_type_filters' ] );
 	}
 
 	/**
-	 * Attach column + row-action filters to every revision-enabled post type.
+	 * Attaches column + row-action filters to every revision-enabled post type.
 	 */
 	public static function hook_post_type_filters(): void {
 		foreach ( self::supported_post_types() as $post_type ) {
@@ -46,7 +46,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Insert our column after the date column (or at the end if date is absent).
+	 * Inserts our column after the date column (or at the end if date is absent).
 	 *
 	 * @param array<string, string> $columns Existing columns map.
 	 * @return array<string, string>
@@ -70,7 +70,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Print the revision count for a given post.
+	 * Prints the revision count for a given post.
 	 *
 	 * @param string $column  Current column slug being rendered.
 	 * @param int    $post_id Parent post ID for this row.
@@ -94,7 +94,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Append a "Manage revisions" row action linking to the native compare screen.
+	 * Appends a "Manage revisions" row action linking to the native compare screen.
 	 *
 	 * @param array<string, string> $actions Existing row actions.
 	 * @param \WP_Post              $post    Post being rendered.
@@ -139,7 +139,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Return the ID of the latest revision for a post, or null if none.
+	 * Returns the ID of the latest revision for a post, or null if none.
 	 *
 	 * @param int $post_id Parent post ID.
 	 */
@@ -165,7 +165,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Return the revision count for a single post, hitting the batch cache.
+	 * Returns the revision count for a single post, hitting the batch cache.
 	 *
 	 * @param int $post_id Parent post ID.
 	 */
@@ -177,14 +177,14 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Reset the per-request cache. Intended for tests.
+	 * Resets the per-request cache. Intended for tests.
 	 */
 	public static function reset_cache(): void {
 		self::$counts = null;
 	}
 
 	/**
-	 * Load a revision-count map keyed by parent post ID.
+	 * Loads a revision-count map keyed by parent post ID.
 	 *
 	 * Scoped to the post IDs on the current admin list screen (via the main
 	 * $wp_query) so we don't aggregate across every revision on the site. If
@@ -234,7 +234,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Extract post IDs from the main $wp_query's current page of results.
+	 * Extracts post IDs from the main $wp_query's current page of results.
 	 *
 	 * @param mixed $wp_query Global $wp_query reference (WP_Query or null).
 	 * @return array<int, int>

--- a/src/Admin/PostListColumn.php
+++ b/src/Admin/PostListColumn.php
@@ -115,7 +115,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * URL of the native revision compare screen for a post.
+	 * Returns the URL of the native revision compare screen for a post.
 	 *
 	 * Note: revision.php expects a revision ID (post_type=revision), not the
 	 * parent post ID. If we can find the latest revision, link directly to it;
@@ -263,7 +263,7 @@ final class PostListColumn {
 	}
 
 	/**
-	 * Public post types that support revisions.
+	 * Returns public post types that support revisions.
 	 *
 	 * @return array<int, string>
 	 */

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -21,8 +21,6 @@ final class RevisionLimitMetaBox {
 
 	public const NONCE_NAME = 'advanced_revisions_override_nonce';
 
-	public const CAPABILITY = 'edit_others_posts';
-
 	/**
 	 * Register the add/save hooks and expose the meta to REST.
 	 */
@@ -44,7 +42,10 @@ final class RevisionLimitMetaBox {
 					'type'          => 'integer',
 					'single'        => true,
 					'show_in_rest'  => true,
-					'auth_callback' => static fn(): bool => current_user_can( self::CAPABILITY ),
+					'auth_callback' => static function ( bool $allowed, string $meta_key, int $object_id ): bool {
+						unset( $allowed, $meta_key );
+						return current_user_can( 'edit_post', $object_id );
+					},
 				],
 			);
 		}
@@ -110,7 +111,7 @@ final class RevisionLimitMetaBox {
 			return;
 		}
 
-		if ( ! current_user_can( self::CAPABILITY, $post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -140,7 +140,7 @@ final class RevisionLimitMetaBox {
 	}
 
 	/**
-	 * Public post types that support revisions.
+	 * Returns public post types that support revisions.
 	 *
 	 * @return array<int, string>
 	 */

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -22,7 +22,7 @@ final class RevisionLimitMetaBox {
 	public const NONCE_NAME = 'advanced_revisions_override_nonce';
 
 	/**
-	 * Register the add/save hooks and expose the meta to REST.
+	 * Registers the add/save hooks and expose the meta to REST.
 	 */
 	public static function register(): void {
 		add_action( 'add_meta_boxes', [ self::class, 'add_meta_box' ] );
@@ -31,7 +31,7 @@ final class RevisionLimitMetaBox {
 	}
 
 	/**
-	 * Expose the override meta to REST so block-editor clients can manage it.
+	 * Exposes the override meta to REST so block-editor clients can manage it.
 	 */
 	public static function register_post_meta(): void {
 		foreach ( self::revisable_post_types() as $post_type ) {
@@ -52,7 +52,7 @@ final class RevisionLimitMetaBox {
 	}
 
 	/**
-	 * Add the meta box to every revision-supporting public post type.
+	 * Adds the meta box to every revision-supporting public post type.
 	 */
 	public static function add_meta_box(): void {
 		foreach ( self::revisable_post_types() as $post_type ) {
@@ -68,7 +68,7 @@ final class RevisionLimitMetaBox {
 	}
 
 	/**
-	 * Render the meta box body.
+	 * Renders the meta box body.
 	 *
 	 * @param WP_Post $post Current post.
 	 */
@@ -94,7 +94,7 @@ final class RevisionLimitMetaBox {
 	}
 
 	/**
-	 * Persist the submitted override on save_post.
+	 * Persists the submitted override on save_post.
 	 *
 	 * @param int     $post_id Post being saved.
 	 * @param WP_Post $post    Post object.

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Admin;
+
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+use WP_Post;
+
+/**
+ * Adds a "Revision retention" meta box to the post edit screen. Lets editors
+ * override the per-post-type limit for one specific post — useful for
+ * high-churn landing pages or legally-sensitive content.
+ *
+ * Precedence: per-post override (this class) > per-type limit (Settings page)
+ * > WP_POST_REVISIONS fallback. See {@see LimitService::filter_revisions_to_keep()}.
+ */
+final class RevisionLimitMetaBox {
+
+	public const NONCE_ACTION = 'advanced_revisions_override_save';
+
+	public const NONCE_NAME = 'advanced_revisions_override_nonce';
+
+	public const CAPABILITY = 'edit_others_posts';
+
+	/**
+	 * Register the add/save hooks and expose the meta to REST.
+	 */
+	public static function register(): void {
+		add_action( 'add_meta_boxes', [ self::class, 'add_meta_box' ] );
+		add_action( 'save_post', [ self::class, 'save' ], 10, 2 );
+		add_action( 'init', [ self::class, 'register_post_meta' ] );
+	}
+
+	/**
+	 * Expose the override meta to REST so block-editor clients can manage it.
+	 */
+	public static function register_post_meta(): void {
+		foreach ( self::revisable_post_types() as $post_type ) {
+			register_post_meta(
+				$post_type,
+				LimitService::PER_POST_META_KEY,
+				[
+					'type'          => 'integer',
+					'single'        => true,
+					'show_in_rest'  => true,
+					'auth_callback' => static fn(): bool => current_user_can( self::CAPABILITY ),
+				],
+			);
+		}
+	}
+
+	/**
+	 * Add the meta box to every revision-supporting public post type.
+	 */
+	public static function add_meta_box(): void {
+		foreach ( self::revisable_post_types() as $post_type ) {
+			add_meta_box(
+				'advanced_revisions_override',
+				__( 'Revision retention', 'advanced-revisions' ),
+				[ self::class, 'render' ],
+				$post_type,
+				'side',
+				'low',
+			);
+		}
+	}
+
+	/**
+	 * Render the meta box body.
+	 *
+	 * @param WP_Post $post Current post.
+	 */
+	public static function render( WP_Post $post ): void {
+		wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
+
+		$current    = LimitService::per_post_override( $post->ID );
+		$value_attr = $current === null ? '' : (string) $current;
+
+		\printf(
+			'<p><label for="%1$s">%2$s</label></p>',
+			esc_attr( LimitService::PER_POST_META_KEY ),
+			esc_html__( 'Override the revision limit for this post:', 'advanced-revisions' ),
+		);
+		\printf(
+			'<input type="number" min="-1" step="1" id="%1$s" name="%1$s" value="%2$s" class="small-text" />',
+			esc_attr( LimitService::PER_POST_META_KEY ),
+			esc_attr( $value_attr ),
+		);
+		echo '<p class="description">';
+		echo esc_html__( 'Leave blank to use the post type default. -1 = unlimited, 0 = disable revisions for this post.', 'advanced-revisions' );
+		echo '</p>';
+	}
+
+	/**
+	 * Persist the submitted override on save_post.
+	 *
+	 * @param int     $post_id Post being saved.
+	 * @param WP_Post $post    Post object.
+	 */
+	public static function save( int $post_id, WP_Post $post ): void {
+		if ( \defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE ) {
+			return;
+		}
+
+		$nonce = isset( $_POST[ self::NONCE_NAME ] ) && \is_string( $_POST[ self::NONCE_NAME ] )
+			? sanitize_text_field( wp_unslash( $_POST[ self::NONCE_NAME ] ) )
+			: '';
+		if ( $nonce === '' || ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( self::CAPABILITY, $post_id ) ) {
+			return;
+		}
+
+		if ( ! \array_key_exists( LimitService::PER_POST_META_KEY, $_POST ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- numeric value; coerced to int via (int) cast before storage (line 137).
+		$raw_value = $_POST[ LimitService::PER_POST_META_KEY ];
+		$raw       = \is_scalar( $raw_value )
+			? (string) $raw_value
+			: '';
+
+		unset( $post );
+
+		if ( \trim( $raw ) === '' ) {
+			delete_post_meta( $post_id, LimitService::PER_POST_META_KEY );
+			return;
+		}
+
+		update_post_meta(
+			$post_id,
+			LimitService::PER_POST_META_KEY,
+			\max( LimitService::UNLIMITED, (int) $raw ),
+		);
+	}
+
+	/**
+	 * Public post types that support revisions.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function revisable_post_types(): array {
+		$types = [];
+		foreach ( get_post_types( [ 'public' => true ], 'names' ) as $post_type ) {
+			if ( post_type_supports( $post_type, 'revisions' ) ) {
+				$types[] = $post_type;
+			}
+		}
+		return $types;
+	}
+}

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -42,8 +42,17 @@ final class RevisionLimitMetaBox {
 					'type'          => 'integer',
 					'single'        => true,
 					'show_in_rest'  => true,
-					'auth_callback' => static function ( bool $allowed, string $meta_key, int $object_id ): bool {
-						unset( $allowed, $meta_key );
+					// WP's map_meta_cap() invokes this filter with 6 positional
+					// args ($allowed, $meta_key, $object_id, $user_id, $cap,
+					// $caps). The variadic $extras catches the trailing ones so
+					// the signature stays compatible as core evolves. We honor
+					// an earlier filter's denial (strict-false $allowed) and
+					// otherwise run the meta-cap check for this post.
+					'auth_callback' => static function ( ?bool $allowed, string $meta_key, int $object_id, ...$extras ): bool {
+						unset( $meta_key, $extras );
+						if ( $allowed === false ) {
+							return false;
+						}
 						return current_user_can( 'edit_post', $object_id );
 					},
 				],

--- a/src/Admin/RevisionLimitMetaBox.php
+++ b/src/Admin/RevisionLimitMetaBox.php
@@ -27,7 +27,10 @@ final class RevisionLimitMetaBox {
 	public static function register(): void {
 		add_action( 'add_meta_boxes', [ self::class, 'add_meta_box' ] );
 		add_action( 'save_post', [ self::class, 'save' ], 10, 2 );
-		add_action( 'init', [ self::class, 'register_post_meta' ] );
+		// wp_loaded runs after every plugin's init, so revisable_post_types()
+		// inside register_post_meta() sees CPTs registered at any init priority
+		// (plugins registering at init:10 after ours would otherwise be missed).
+		add_action( 'wp_loaded', [ self::class, 'register_post_meta' ] );
 	}
 
 	/**

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Admin;
+
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+
+/**
+ * Renders the **Settings → Revisions** page. Uses the Settings API so the page
+ * looks and behaves exactly like native WordPress configuration screens.
+ *
+ * One setting for now: per-post-type revision limits. More sections will be
+ * added as v0.1.0+ features land.
+ */
+final class SettingsPage {
+
+	public const MENU_SLUG = 'advanced-revisions';
+
+	public const SECTION_ID = 'advanced_revisions_limits_section';
+
+	public const CAPABILITY = 'manage_options';
+
+	/**
+	 * Wire the admin-menu and admin-init hooks.
+	 */
+	public static function register(): void {
+		add_action( 'admin_menu', [ self::class, 'add_page' ] );
+		add_action( 'admin_init', [ self::class, 'register_settings' ] );
+	}
+
+	/**
+	 * Add the page under Settings.
+	 */
+	public static function add_page(): void {
+		add_options_page(
+			__( 'Advanced Revisions', 'advanced-revisions' ),
+			__( 'Revisions', 'advanced-revisions' ),
+			self::CAPABILITY,
+			self::MENU_SLUG,
+			[ self::class, 'render_page' ],
+		);
+	}
+
+	/**
+	 * Register the settings, section, and field.
+	 */
+	public static function register_settings(): void {
+		register_setting(
+			self::MENU_SLUG,
+			LimitService::OPTION_NAME,
+			[
+				'type'              => 'array',
+				'sanitize_callback' => [ self::class, 'sanitize_settings' ],
+				'default'           => [ LimitService::LIMITS_KEY => [] ],
+			],
+		);
+
+		add_settings_section(
+			self::SECTION_ID,
+			__( 'Revisions per post type', 'advanced-revisions' ),
+			[ self::class, 'render_section_intro' ],
+			self::MENU_SLUG,
+		);
+
+		foreach ( self::revisable_post_types() as $post_type => $label ) {
+			add_settings_field(
+				'limit_' . $post_type,
+				$label,
+				[ self::class, 'render_limit_field' ],
+				self::MENU_SLUG,
+				self::SECTION_ID,
+				[ 'post_type' => $post_type ],
+			);
+		}
+	}
+
+	/**
+	 * Render the short intro above the per-post-type fields.
+	 */
+	public static function render_section_intro(): void {
+		echo '<p>';
+		echo esc_html__(
+			'Set how many revisions to keep for each post type. Leave blank to inherit the site-wide WP_POST_REVISIONS default. Use -1 for unlimited and 0 to disable revisions.',
+			'advanced-revisions',
+		);
+		echo '</p>';
+	}
+
+	/**
+	 * Render one numeric input for a single post type.
+	 *
+	 * @param array<string, mixed> $args Callback args — 'post_type' key required.
+	 */
+	public static function render_limit_field( array $args ): void {
+		$post_type = isset( $args['post_type'] ) && \is_string( $args['post_type'] )
+			? $args['post_type']
+			: '';
+		if ( $post_type === '' ) {
+			return;
+		}
+
+		$current    = LimitService::limit_for_type( $post_type );
+		$value_attr = $current === null ? '' : (string) $current;
+		$name_attr  = LimitService::OPTION_NAME . '[' . LimitService::LIMITS_KEY . '][' . $post_type . ']';
+
+		\printf(
+			'<input type="number" min="-1" step="1" name="%1$s" value="%2$s" class="small-text" />',
+			esc_attr( $name_attr ),
+			esc_attr( $value_attr ),
+		);
+	}
+
+	/**
+	 * Render the settings page shell — Settings API does the form rendering.
+	 */
+	public static function render_page(): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			return;
+		}
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Advanced Revisions', 'advanced-revisions' ) . '</h1>';
+		echo '<form method="post" action="options.php">';
+		settings_fields( self::MENU_SLUG );
+		do_settings_sections( self::MENU_SLUG );
+		submit_button();
+		echo '</form>';
+		echo '</div>';
+	}
+
+	/**
+	 * Sanitize submitted settings — clamp to int, drop unknown post types,
+	 * remove blank entries so defaults fall through cleanly.
+	 *
+	 * @param mixed $input Raw submitted value.
+	 * @return array<string, array<string, int>>
+	 */
+	public static function sanitize_settings( mixed $input ): array {
+		if ( ! \is_array( $input ) ) {
+			return [ LimitService::LIMITS_KEY => [] ];
+		}
+
+		$submitted = $input[ LimitService::LIMITS_KEY ] ?? [];
+		if ( ! \is_array( $submitted ) ) {
+			$submitted = [];
+		}
+
+		$known   = \array_keys( self::revisable_post_types() );
+		$cleaned = [];
+		foreach ( $submitted as $post_type => $raw ) {
+			if ( ! \is_string( $post_type ) || ! \in_array( $post_type, $known, true ) ) {
+				continue;
+			}
+			if ( $raw === '' || $raw === null ) {
+				continue;
+			}
+			$cleaned[ $post_type ] = \max( LimitService::UNLIMITED, (int) $raw );
+		}
+
+		return [ LimitService::LIMITS_KEY => $cleaned ];
+	}
+
+	/**
+	 * Public post types that actually support revisions, keyed slug → label.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function revisable_post_types(): array {
+		$types = [];
+		foreach ( get_post_types( [ 'public' => true ], 'objects' ) as $post_type ) {
+			if ( ! post_type_supports( $post_type->name, 'revisions' ) ) {
+				continue;
+			}
+			$types[ $post_type->name ] = $post_type->labels->name ?? $post_type->name;
+		}
+		return $types;
+	}
+}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -19,7 +19,7 @@ final class SettingsPage {
 
 	public const SECTION_ID = 'advanced_revisions_limits_section';
 
-	public const CAPABILITY = 'manage_options';
+	public const REQUIRED_CAPABILITY = 'manage_options';
 
 	/**
 	 * Wires the admin-menu and admin-init hooks.
@@ -36,7 +36,7 @@ final class SettingsPage {
 		add_options_page(
 			__( 'Advanced Revisions', 'advanced-revisions' ),
 			__( 'Revisions', 'advanced-revisions' ),
-			self::CAPABILITY,
+			self::REQUIRED_CAPABILITY,
 			self::MENU_SLUG,
 			[ self::class, 'render_page' ],
 		);
@@ -115,7 +115,7 @@ final class SettingsPage {
 	 * Renders the settings page shell — Settings API does the form rendering.
 	 */
 	public static function render_page(): void {
-		if ( ! current_user_can( self::CAPABILITY ) ) {
+		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
 			return;
 		}
 		echo '<div class="wrap">';
@@ -129,8 +129,8 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Sanitize submitted settings — clamp to int, drop unknown post types,
-	 * remove blank entries so defaults fall through cleanly.
+	 * Sanitizes submitted settings — clamps to int, drops unknown post types,
+	 * removes blank entries so defaults fall through cleanly.
 	 *
 	 * @param mixed $input Raw submitted value.
 	 * @return array<string, array<string, int>>
@@ -161,7 +161,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Public post types that actually support revisions, keyed slug → label.
+	 * Returns public post types that actually support revisions, keyed slug → label.
 	 *
 	 * @return array<string, string>
 	 */

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -22,7 +22,7 @@ final class SettingsPage {
 	public const CAPABILITY = 'manage_options';
 
 	/**
-	 * Wire the admin-menu and admin-init hooks.
+	 * Wires the admin-menu and admin-init hooks.
 	 */
 	public static function register(): void {
 		add_action( 'admin_menu', [ self::class, 'add_page' ] );
@@ -30,7 +30,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Add the page under Settings.
+	 * Adds the page under Settings.
 	 */
 	public static function add_page(): void {
 		add_options_page(
@@ -43,7 +43,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Register the settings, section, and field.
+	 * Registers the settings, section, and field.
 	 */
 	public static function register_settings(): void {
 		register_setting(
@@ -76,7 +76,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Render the short intro above the per-post-type fields.
+	 * Renders the short intro above the per-post-type fields.
 	 */
 	public static function render_section_intro(): void {
 		echo '<p>';
@@ -88,7 +88,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Render one numeric input for a single post type.
+	 * Renders one numeric input for a single post type.
 	 *
 	 * @param array<string, mixed> $args Callback args — 'post_type' key required.
 	 */
@@ -112,7 +112,7 @@ final class SettingsPage {
 	}
 
 	/**
-	 * Render the settings page shell — Settings API does the form rendering.
+	 * Renders the settings page shell — Settings API does the form rendering.
 	 */
 	public static function render_page(): void {
 		if ( ! current_user_can( self::CAPABILITY ) ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,7 +13,7 @@ use Apermo\AdvancedRevisions\Revisions\LimitService;
 use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
 
 /**
- * Main plugin class.
+ * Represents the main plugin class.
  */
 class Plugin {
 
@@ -27,7 +27,7 @@ class Plugin {
 	private static string $file = '';
 
 	/**
-	 * Initialize the plugin.
+	 * Initializes the plugin.
 	 *
 	 * @param string $file Main plugin file path.
 	 *
@@ -51,7 +51,7 @@ class Plugin {
 	}
 
 	/**
-	 * Plugin activation.
+	 * Runs on plugin activation.
 	 *
 	 * @return void
 	 */
@@ -60,7 +60,7 @@ class Plugin {
 	}
 
 	/**
-	 * Plugin deactivation.
+	 * Runs on plugin deactivation.
 	 *
 	 * @return void
 	 */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisions;
 
 use Apermo\AdvancedRevisions\Admin\DashboardWidget;
+use Apermo\AdvancedRevisions\Admin\OverviewPage;
 use Apermo\AdvancedRevisions\Admin\PostListColumn;
 use Apermo\AdvancedRevisions\Admin\RevisionLimitMetaBox;
 use Apermo\AdvancedRevisions\Admin\SettingsPage;
@@ -80,6 +81,7 @@ class Plugin {
 			PostListColumn::register();
 			DashboardWidget::register();
 			RevisionLimitMetaBox::register();
+			OverviewPage::register();
 		}
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ namespace Apermo\AdvancedRevisions;
 use Apermo\AdvancedRevisions\Admin\PostListColumn;
 use Apermo\AdvancedRevisions\Admin\SettingsPage;
 use Apermo\AdvancedRevisions\Revisions\LimitService;
+use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
 
 /**
  * Main plugin class.
@@ -71,6 +72,7 @@ class Plugin {
 	 */
 	public static function boot(): void {
 		LimitService::register();
+		TaxonomyRegistrar::register();
 		if ( is_admin() ) {
 			SettingsPage::register();
 			PostListColumn::register();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisions;
 
+use Apermo\AdvancedRevisions\Admin\SettingsPage;
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+
 /**
  * Main plugin class.
  */
@@ -66,6 +69,9 @@ class Plugin {
 	 * @return void
 	 */
 	public static function boot(): void {
-		// Initialize plugin functionality.
+		LimitService::register();
+		if ( is_admin() ) {
+			SettingsPage::register();
+		}
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,7 +42,7 @@ class Plugin {
 	}
 
 	/**
-	 * Return the main plugin file path.
+	 * Returns the main plugin file path.
 	 *
 	 * @return string
 	 */
@@ -69,7 +69,7 @@ class Plugin {
 	}
 
 	/**
-	 * Boot the plugin after all plugins are loaded.
+	 * Boots the plugin after all plugins are loaded.
 	 *
 	 * @return void
 	 */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisions;
 
+use Apermo\AdvancedRevisions\Admin\PostListColumn;
 use Apermo\AdvancedRevisions\Admin\SettingsPage;
 use Apermo\AdvancedRevisions\Revisions\LimitService;
 
@@ -72,6 +73,7 @@ class Plugin {
 		LimitService::register();
 		if ( is_admin() ) {
 			SettingsPage::register();
+			PostListColumn::register();
 		}
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,6 +6,7 @@ namespace Apermo\AdvancedRevisions;
 
 use Apermo\AdvancedRevisions\Admin\DashboardWidget;
 use Apermo\AdvancedRevisions\Admin\PostListColumn;
+use Apermo\AdvancedRevisions\Admin\RevisionLimitMetaBox;
 use Apermo\AdvancedRevisions\Admin\SettingsPage;
 use Apermo\AdvancedRevisions\Revisions\LimitService;
 use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
@@ -78,6 +79,7 @@ class Plugin {
 			SettingsPage::register();
 			PostListColumn::register();
 			DashboardWidget::register();
+			RevisionLimitMetaBox::register();
 		}
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\AdvancedRevisions;
 
+use Apermo\AdvancedRevisions\Admin\DashboardWidget;
 use Apermo\AdvancedRevisions\Admin\PostListColumn;
 use Apermo\AdvancedRevisions\Admin\SettingsPage;
 use Apermo\AdvancedRevisions\Revisions\LimitService;
@@ -76,6 +77,7 @@ class Plugin {
 		if ( is_admin() ) {
 			SettingsPage::register();
 			PostListColumn::register();
+			DashboardWidget::register();
 		}
 	}
 }

--- a/src/Revisions/LimitService.php
+++ b/src/Revisions/LimitService.php
@@ -28,6 +28,8 @@ final class LimitService {
 
 	public const UNLIMITED = -1;
 
+	public const PER_POST_META_KEY = '_advanced_revisions_keep';
+
 	/**
 	 * Register the filter. Safe to call multiple times — the filter is idempotent.
 	 */
@@ -42,11 +44,32 @@ final class LimitService {
 	 * @param WP_Post $post Post being saved.
 	 */
 	public static function filter_revisions_to_keep( int $num, WP_Post $post ): int {
+		$override = self::per_post_override( $post->ID );
+		if ( $override !== null ) {
+			return $override;
+		}
+
 		$configured = self::limit_for_type( $post->post_type );
 		if ( $configured === null ) {
 			return $num;
 		}
 		return $configured;
+	}
+
+	/**
+	 * Return a per-post override, or null if the post has no override set.
+	 *
+	 * Empty string, false, or null meta values mean "inherit" — return null
+	 * so the caller falls through to the per-type rule.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function per_post_override( int $post_id ): ?int {
+		$raw = get_post_meta( $post_id, self::PER_POST_META_KEY, true );
+		if ( $raw === '' || $raw === false || $raw === null ) {
+			return null;
+		}
+		return \max( self::UNLIMITED, (int) $raw );
 	}
 
 	/**

--- a/src/Revisions/LimitService.php
+++ b/src/Revisions/LimitService.php
@@ -31,14 +31,14 @@ final class LimitService {
 	public const PER_POST_META_KEY = '_advanced_revisions_keep';
 
 	/**
-	 * Register the filter. Safe to call multiple times — the filter is idempotent.
+	 * Registers the filter. Safe to call multiple times — the filter is idempotent.
 	 */
 	public static function register(): void {
 		add_filter( 'wp_revisions_to_keep', [ self::class, 'filter_revisions_to_keep' ], 10, 2 );
 	}
 
 	/**
-	 * Override the revision count for a given post based on its type.
+	 * Overrides the revision count for a given post based on its type.
 	 *
 	 * @param int     $num  Current revision count (from core or an earlier filter).
 	 * @param WP_Post $post Post being saved.
@@ -57,7 +57,7 @@ final class LimitService {
 	}
 
 	/**
-	 * Return a per-post override, or null if the post has no override set.
+	 * Returns a per-post override, or null if the post has no override set.
 	 *
 	 * Empty string, false, or null meta values mean "inherit" — return null
 	 * so the caller falls through to the per-type rule.

--- a/src/Revisions/LimitService.php
+++ b/src/Revisions/LimitService.php
@@ -73,7 +73,7 @@ final class LimitService {
 	}
 
 	/**
-	 * Read the configured limit for a post type. Returns null when no override
+	 * Reads the configured limit for a post type. Returns null when no override
 	 * is set, meaning "use core's default / WP_POST_REVISIONS".
 	 *
 	 * @param string $post_type Post type slug.
@@ -87,7 +87,7 @@ final class LimitService {
 	}
 
 	/**
-	 * Read the limits map from the settings option.
+	 * Reads the limits map from the settings option.
 	 *
 	 * @return array<string, int>
 	 */

--- a/src/Revisions/LimitService.php
+++ b/src/Revisions/LimitService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Revisions;
+
+use WP_Post;
+
+/**
+ * Applies per-post-type revision limits by hooking `wp_revisions_to_keep`.
+ *
+ * Options shape (under option name {@see self::OPTION_NAME}):
+ *
+ *     [
+ *         'limits' => [ 'post' => 10, 'page' => -1, 'product' => 0 ],
+ *     ]
+ *
+ * Where the integer value is passed straight to core as the "revisions to keep"
+ * count. Core treats -1 as "unlimited" and 0 as "disable revisions".
+ *
+ * A post type with no entry in `limits` falls through to WP_POST_REVISIONS.
+ */
+final class LimitService {
+
+	public const OPTION_NAME = 'advanced_revisions_settings';
+
+	public const LIMITS_KEY = 'limits';
+
+	public const UNLIMITED = -1;
+
+	/**
+	 * Register the filter. Safe to call multiple times — the filter is idempotent.
+	 */
+	public static function register(): void {
+		add_filter( 'wp_revisions_to_keep', [ self::class, 'filter_revisions_to_keep' ], 10, 2 );
+	}
+
+	/**
+	 * Override the revision count for a given post based on its type.
+	 *
+	 * @param int     $num  Current revision count (from core or an earlier filter).
+	 * @param WP_Post $post Post being saved.
+	 */
+	public static function filter_revisions_to_keep( int $num, WP_Post $post ): int {
+		$configured = self::limit_for_type( $post->post_type );
+		if ( $configured === null ) {
+			return $num;
+		}
+		return $configured;
+	}
+
+	/**
+	 * Read the configured limit for a post type. Returns null when no override
+	 * is set, meaning "use core's default / WP_POST_REVISIONS".
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	public static function limit_for_type( string $post_type ): ?int {
+		$limits = self::stored_limits();
+		if ( ! \array_key_exists( $post_type, $limits ) ) {
+			return null;
+		}
+		return $limits[ $post_type ];
+	}
+
+	/**
+	 * Read the limits map from the settings option.
+	 *
+	 * @return array<string, int>
+	 */
+	public static function stored_limits(): array {
+		$option = get_option( self::OPTION_NAME, [] );
+		if ( ! \is_array( $option ) ) {
+			return [];
+		}
+		$limits = $option[ self::LIMITS_KEY ] ?? [];
+		if ( ! \is_array( $limits ) ) {
+			return [];
+		}
+
+		$sanitized = [];
+		foreach ( $limits as $post_type => $value ) {
+			if ( ! \is_string( $post_type ) ) {
+				continue;
+			}
+			$sanitized[ $post_type ] = \max( self::UNLIMITED, (int) $value );
+		}
+		return $sanitized;
+	}
+}

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -17,7 +17,7 @@ namespace Apermo\AdvancedRevisions\Revisions;
 final class ProtectionService {
 
 	/**
-	 * Return the subset of $revision_ids that is safe to delete.
+	 * Returns the subset of $revision_ids that is safe to delete.
 	 *
 	 * An ID is removed from the input when at least one tag attached to it
 	 * has its `protected` term meta set to a truthy value.
@@ -56,7 +56,7 @@ final class ProtectionService {
 	}
 
 	/**
-	 * Return the subset of IDs that are currently protected.
+	 * Returns the subset of IDs that are currently protected.
 	 *
 	 * Strategy:
 	 * 1. Batch-fetch revision→term relationships (single DB hit via wp_get_object_terms).
@@ -91,7 +91,7 @@ final class ProtectionService {
 	}
 
 	/**
-	 * Fetch term IDs grouped by revision in a single batched query.
+	 * Fetches term IDs grouped by revision in a single batched query.
 	 *
 	 * Passes the whole revision-ID array to wp_get_object_terms() with
 	 * `all_with_object_id` so we get back rows that know which revision they
@@ -145,7 +145,7 @@ final class ProtectionService {
 	}
 
 	/**
-	 * Build a lookup of term_id → true for terms flagged protected.
+	 * Builds a lookup of term_id → true for terms flagged protected.
 	 *
 	 * @param array<int, int> $term_ids Unique term IDs to inspect.
 	 * @return array<int, bool>

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -30,15 +30,15 @@ final class ProtectionService {
 			return [];
 		}
 
-		$protected = self::protected_revision_ids( $revision_ids );
-		if ( $protected === [] ) {
+		$protected_lookup = \array_flip( self::protected_revision_ids( $revision_ids ) );
+		if ( $protected_lookup === [] ) {
 			return \array_values( $revision_ids );
 		}
 
 		return \array_values(
 			\array_filter(
 				$revision_ids,
-				static fn( int $id ): bool => ! \in_array( $id, $protected, true ),
+				static fn( int $id ): bool => ! isset( $protected_lookup[ $id ] ),
 			),
 		);
 	}
@@ -58,43 +58,91 @@ final class ProtectionService {
 	/**
 	 * Return the subset of IDs that are currently protected.
 	 *
-	 * Strategy: walk each ID, look up its revision_tag terms, and if any of
-	 * those terms has the `protected` term meta set truthy, flag the ID.
+	 * Strategy:
+	 * 1. Batch-fetch revision→term relationships (single DB hit via wp_get_object_terms).
+	 * 2. Build a map of term_id → protected flag by priming term meta once.
+	 * 3. Walk the input, marking any revision that wears a protected term.
 	 *
 	 * @param array<int, int> $revision_ids Revision IDs to check.
 	 * @return array<int, int> Protected subset.
 	 */
 	private static function protected_revision_ids( array $revision_ids ): array {
-		$protected = [];
-
-		foreach ( $revision_ids as $revision_id ) {
-			if ( self::is_revision_protected( $revision_id ) ) {
-				$protected[] = $revision_id;
-			}
+		$terms_by_revision = self::terms_by_revision( $revision_ids );
+		if ( $terms_by_revision === [] ) {
+			return [];
 		}
 
+		$unique_term_ids = self::unique_term_ids( $terms_by_revision );
+		$protected_terms = self::protected_term_lookup( $unique_term_ids );
+		if ( $protected_terms === [] ) {
+			return [];
+		}
+
+		$protected = [];
+		foreach ( $terms_by_revision as $revision_id => $term_ids ) {
+			foreach ( $term_ids as $term_id ) {
+				if ( isset( $protected_terms[ $term_id ] ) ) {
+					$protected[] = $revision_id;
+					break;
+				}
+			}
+		}
 		return $protected;
 	}
 
 	/**
-	 * True when this revision wears at least one tag with the protected flag.
+	 * Fetch term IDs for each revision in one call. Revisions without any
+	 * revision_tag terms are omitted from the result.
 	 *
-	 * @param int $revision_id Revision post ID.
+	 * @param array<int, int> $revision_ids Revision IDs.
+	 * @return array<int, array<int, int>>
 	 */
-	private static function is_revision_protected( int $revision_id ): bool {
-		$terms = wp_get_object_terms( $revision_id, TaxonomyRegistrar::TAXONOMY, [ 'fields' => 'ids' ] );
-
-		if ( ! \is_array( $terms ) || $terms === [] ) {
-			return false;
+	private static function terms_by_revision( array $revision_ids ): array {
+		$result = [];
+		foreach ( $revision_ids as $revision_id ) {
+			$terms = wp_get_object_terms(
+				$revision_id,
+				TaxonomyRegistrar::TAXONOMY,
+				[ 'fields' => 'ids' ],
+			);
+			if ( ! \is_array( $terms ) || $terms === [] ) {
+				continue;
+			}
+			$result[ $revision_id ] = \array_map( 'intval', $terms );
 		}
+		return $result;
+	}
 
-		foreach ( $terms as $term_id ) {
-			$flag = get_term_meta( $term_id, TaxonomyRegistrar::PROTECTED_META, true );
-			if ( (bool) $flag ) {
-				return true;
+	/**
+	 * Unique term IDs across all fetched revisions.
+	 *
+	 * @param array<int, array<int, int>> $terms_by_revision Per-revision term ID list.
+	 * @return array<int, int>
+	 */
+	private static function unique_term_ids( array $terms_by_revision ): array {
+		$ids = [];
+		foreach ( $terms_by_revision as $term_ids ) {
+			foreach ( $term_ids as $term_id ) {
+				$ids[ $term_id ] = $term_id;
 			}
 		}
+		return \array_values( $ids );
+	}
 
-		return false;
+	/**
+	 * Build a lookup of term_id → true for terms flagged protected.
+	 *
+	 * @param array<int, int> $term_ids Unique term IDs to inspect.
+	 * @return array<int, bool>
+	 */
+	private static function protected_term_lookup( array $term_ids ): array {
+		$lookup = [];
+		foreach ( $term_ids as $term_id ) {
+			$flag = get_term_meta( $term_id, TaxonomyRegistrar::PROTECTED_META, true );
+			if ( (bool) $flag ) {
+				$lookup[ $term_id ] = true;
+			}
+		}
+		return $lookup;
 	}
 }

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisions\Revisions;
 
 /**
- * Central protection check consumed by every cleanup path (#3, #5, #6, #7).
+ * Centralizes the protection check consumed by every cleanup path (#3, #5, #6, #7).
  *
  * Given a list of revision IDs, {@see self::filter_deletable()} returns the
  * subset that is NOT wearing a tag with the `protected` term meta flag set.
@@ -44,7 +44,7 @@ final class ProtectionService {
 	}
 
 	/**
-	 * How many of the given IDs are protected. Handy for confirmation UIs.
+	 * Counts how many of the given IDs are protected. Handy for confirmation UIs.
 	 *
 	 * @param array<int, int> $revision_ids Revision IDs to count.
 	 */
@@ -129,7 +129,7 @@ final class ProtectionService {
 	}
 
 	/**
-	 * Unique term IDs across all fetched revisions.
+	 * Collects unique term IDs across all fetched revisions.
 	 *
 	 * @param array<int, array<int, int>> $terms_by_revision Per-revision term ID list.
 	 * @return array<int, int>

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -91,24 +91,39 @@ final class ProtectionService {
 	}
 
 	/**
-	 * Fetch term IDs for each revision in one call. Revisions without any
-	 * revision_tag terms are omitted from the result.
+	 * Fetch term IDs grouped by revision in a single batched query.
+	 *
+	 * Passes the whole revision-ID array to wp_get_object_terms() with
+	 * `all_with_object_id` so we get back rows that know which revision they
+	 * belong to — avoiding the N+1 pattern a per-revision loop would cause.
+	 * Revisions without any revision_tag terms are omitted from the result.
 	 *
 	 * @param array<int, int> $revision_ids Revision IDs.
 	 * @return array<int, array<int, int>>
 	 */
 	private static function terms_by_revision( array $revision_ids ): array {
+		$rows = wp_get_object_terms(
+			$revision_ids,
+			TaxonomyRegistrar::TAXONOMY,
+			[ 'fields' => 'all_with_object_id' ],
+		);
+
+		if ( ! \is_array( $rows ) || $rows === [] ) {
+			return [];
+		}
+
 		$result = [];
-		foreach ( $revision_ids as $revision_id ) {
-			$terms = wp_get_object_terms(
-				$revision_id,
-				TaxonomyRegistrar::TAXONOMY,
-				[ 'fields' => 'ids' ],
-			);
-			if ( ! \is_array( $terms ) || $terms === [] ) {
+		foreach ( $rows as $row_data ) {
+			// @phpstan-ignore-next-line property.notFound -- all_with_object_id injects an object_id on each WP_Term row.
+			$object_id = isset( $row_data->object_id ) ? (int) $row_data->object_id : 0;
+			$term_id   = $row_data->term_id;
+			if ( $object_id === 0 || $term_id === 0 ) {
 				continue;
 			}
-			$result[ $revision_id ] = \array_map( 'intval', $terms );
+			if ( ! isset( $result[ $object_id ] ) ) {
+				$result[ $object_id ] = [];
+			}
+			$result[ $object_id ][] = $term_id;
 		}
 		return $result;
 	}

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -147,10 +147,21 @@ final class ProtectionService {
 	/**
 	 * Builds a lookup of term_id → true for terms flagged protected.
 	 *
+	 * Primes the termmeta cache with a single bulk query before the loop so
+	 * subsequent get_term_meta() calls hit the object cache. Without priming,
+	 * a cold cache triggers one SELECT per term — N+1 on bulk-delete flows
+	 * where every revision's tags get inspected.
+	 *
 	 * @param array<int, int> $term_ids Unique term IDs to inspect.
 	 * @return array<int, bool>
 	 */
 	private static function protected_term_lookup( array $term_ids ): array {
+		if ( $term_ids === [] ) {
+			return [];
+		}
+
+		update_termmeta_cache( $term_ids );
+
 		$lookup = [];
 		foreach ( $term_ids as $term_id ) {
 			$flag = get_term_meta( $term_id, TaxonomyRegistrar::PROTECTED_META, true );

--- a/src/Revisions/ProtectionService.php
+++ b/src/Revisions/ProtectionService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Revisions;
+
+/**
+ * Central protection check consumed by every cleanup path (#3, #5, #6, #7).
+ *
+ * Given a list of revision IDs, {@see self::filter_deletable()} returns the
+ * subset that is NOT wearing a tag with the `protected` term meta flag set.
+ *
+ * Protection is a tag attribute (not a per-revision flag) so policy is
+ * declarative: toggle `protected` on a tag and every revision wearing it
+ * becomes safe immediately; untoggle and they're eligible again.
+ */
+final class ProtectionService {
+
+	/**
+	 * Return the subset of $revision_ids that is safe to delete.
+	 *
+	 * An ID is removed from the input when at least one tag attached to it
+	 * has its `protected` term meta set to a truthy value.
+	 *
+	 * @param array<int, int> $revision_ids Revision post IDs to filter.
+	 * @return array<int, int> Same IDs, minus any that are protected.
+	 */
+	public static function filter_deletable( array $revision_ids ): array {
+		if ( $revision_ids === [] ) {
+			return [];
+		}
+
+		$protected = self::protected_revision_ids( $revision_ids );
+		if ( $protected === [] ) {
+			return \array_values( $revision_ids );
+		}
+
+		return \array_values(
+			\array_filter(
+				$revision_ids,
+				static fn( int $id ): bool => ! \in_array( $id, $protected, true ),
+			),
+		);
+	}
+
+	/**
+	 * How many of the given IDs are protected. Handy for confirmation UIs.
+	 *
+	 * @param array<int, int> $revision_ids Revision IDs to count.
+	 */
+	public static function count_protected( array $revision_ids ): int {
+		if ( $revision_ids === [] ) {
+			return 0;
+		}
+		return \count( self::protected_revision_ids( $revision_ids ) );
+	}
+
+	/**
+	 * Return the subset of IDs that are currently protected.
+	 *
+	 * Strategy: walk each ID, look up its revision_tag terms, and if any of
+	 * those terms has the `protected` term meta set truthy, flag the ID.
+	 *
+	 * @param array<int, int> $revision_ids Revision IDs to check.
+	 * @return array<int, int> Protected subset.
+	 */
+	private static function protected_revision_ids( array $revision_ids ): array {
+		$protected = [];
+
+		foreach ( $revision_ids as $revision_id ) {
+			if ( self::is_revision_protected( $revision_id ) ) {
+				$protected[] = $revision_id;
+			}
+		}
+
+		return $protected;
+	}
+
+	/**
+	 * True when this revision wears at least one tag with the protected flag.
+	 *
+	 * @param int $revision_id Revision post ID.
+	 */
+	private static function is_revision_protected( int $revision_id ): bool {
+		$terms = wp_get_object_terms( $revision_id, TaxonomyRegistrar::TAXONOMY, [ 'fields' => 'ids' ] );
+
+		if ( ! \is_array( $terms ) || $terms === [] ) {
+			return false;
+		}
+
+		foreach ( $terms as $term_id ) {
+			$flag = get_term_meta( $term_id, TaxonomyRegistrar::PROTECTED_META, true );
+			if ( (bool) $flag ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Revisions/RevisionDeleter.php
+++ b/src/Revisions/RevisionDeleter.php
@@ -47,7 +47,8 @@ final class RevisionDeleter {
 	public function delete_for_parents( array $parent_ids ): array {
 		$revision_ids = $this->repository->revision_ids_for_parents( $parent_ids );
 		$deletable    = ProtectionService::filter_deletable( $revision_ids );
-		$protected    = \count( $revision_ids ) - \count( $deletable );
+		// Arithmetic avoids a second term-fetch vs. ProtectionService::count_protected().
+		$protected = \count( $revision_ids ) - \count( $deletable );
 
 		$deleted = 0;
 		foreach ( $deletable as $revision_id ) {

--- a/src/Revisions/RevisionDeleter.php
+++ b/src/Revisions/RevisionDeleter.php
@@ -51,7 +51,6 @@ final class RevisionDeleter {
 
 		$deleted = 0;
 		foreach ( $deletable as $revision_id ) {
-			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post_revision typed without WP_Error.
 			$result = wp_delete_post_revision( $revision_id );
 			if ( $result === false || $result === null ) {
 				continue;

--- a/src/Revisions/RevisionDeleter.php
+++ b/src/Revisions/RevisionDeleter.php
@@ -21,8 +21,9 @@ final class RevisionDeleter {
 	}
 
 	/**
-	 * Dry-run: return the number of deletable vs. protected revisions for a
-	 * set of parent posts. Caller can use this to populate a confirmation UI.
+	 * Previews deletable vs. protected revision counts for a set of parent
+	 * posts without deleting anything. Caller can use this to populate a
+	 * confirmation UI.
 	 *
 	 * @param array<int, int> $parent_ids Parent post IDs.
 	 * @return array{deletable:int, protected:int}

--- a/src/Revisions/RevisionDeleter.php
+++ b/src/Revisions/RevisionDeleter.php
@@ -11,7 +11,7 @@ namespace Apermo\AdvancedRevisions\Revisions;
 final class RevisionDeleter {
 
 	/**
-	 * Inject the revision repository.
+	 * Injects the revision repository.
 	 *
 	 * @param RevisionRepository $repository Provides revision IDs per parent.
 	 */
@@ -38,7 +38,7 @@ final class RevisionDeleter {
 	}
 
 	/**
-	 * Delete every unprotected revision belonging to the given parent posts.
+	 * Deletes every unprotected revision belonging to the given parent posts.
 	 *
 	 * @param array<int, int> $parent_ids Parent post IDs.
 	 * @return array{deleted:int, skipped:int}

--- a/src/Revisions/RevisionDeleter.php
+++ b/src/Revisions/RevisionDeleter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Revisions;
+
+/**
+ * Deletes revisions for a set of parent post IDs, honoring the protection
+ * flag from {@see ProtectionService}.
+ */
+final class RevisionDeleter {
+
+	/**
+	 * Inject the revision repository.
+	 *
+	 * @param RevisionRepository $repository Provides revision IDs per parent.
+	 */
+	public function __construct(
+		private readonly RevisionRepository $repository,
+	) {
+	}
+
+	/**
+	 * Dry-run: return the number of deletable vs. protected revisions for a
+	 * set of parent posts. Caller can use this to populate a confirmation UI.
+	 *
+	 * @param array<int, int> $parent_ids Parent post IDs.
+	 * @return array{deletable:int, protected:int}
+	 */
+	public function preview( array $parent_ids ): array {
+		$revision_ids = $this->repository->revision_ids_for_parents( $parent_ids );
+		$deletable    = ProtectionService::filter_deletable( $revision_ids );
+
+		return [
+			'deletable' => \count( $deletable ),
+			'protected' => ProtectionService::count_protected( $revision_ids ),
+		];
+	}
+
+	/**
+	 * Delete every unprotected revision belonging to the given parent posts.
+	 *
+	 * @param array<int, int> $parent_ids Parent post IDs.
+	 * @return array{deleted:int, skipped:int}
+	 */
+	public function delete_for_parents( array $parent_ids ): array {
+		$revision_ids = $this->repository->revision_ids_for_parents( $parent_ids );
+		$deletable    = ProtectionService::filter_deletable( $revision_ids );
+		$protected    = \count( $revision_ids ) - \count( $deletable );
+
+		$deleted = 0;
+		foreach ( $deletable as $revision_id ) {
+			// phpcs:ignore Apermo.WordPress.RequireWpErrorHandling.Unchecked -- wp_delete_post_revision typed without WP_Error.
+			$result = wp_delete_post_revision( $revision_id );
+			if ( $result === false || $result === null ) {
+				continue;
+			}
+			$deleted++;
+		}
+
+		return [
+			'deleted' => $deleted,
+			'skipped' => $protected,
+		];
+	}
+}

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -36,28 +36,34 @@ class RevisionRepository {
 
 		$limit  = \max( 1, \min( 500, $per_page ) );
 		$offset = \max( 0, ( $page - 1 ) * $limit );
+		// Literal LIKE pattern; no user input to escape.
+		$autosave_like = '-autosave-%';
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders -- static LIKE pattern with CONCAT of parent ID (int); no user input.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- direct aggregation is the purpose of this helper; callers cache.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT p.ID, p.post_title, p.post_type, p.post_author,
 					COUNT(r.ID) AS revision_count,
 					MIN(r.post_date_gmt) AS oldest_gmt
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->posts} r
+				FROM %i p
+				INNER JOIN %i r
 					ON r.post_parent = p.ID
 					AND r.post_type = 'revision'
-					AND r.post_name NOT LIKE CONCAT(p.ID, '-autosave-%')
+					AND r.post_name NOT LIKE CONCAT(p.ID, %s)
 				WHERE p.post_type != 'revision'
 					AND p.post_status IN ('publish', 'draft', 'pending', 'private', 'future')
 				GROUP BY p.ID
 				ORDER BY revision_count DESC, p.ID ASC
 				LIMIT %d OFFSET %d",
-				$limit,
-				$offset,
+				[
+					$wpdb->posts,
+					$wpdb->posts,
+					$autosave_like,
+					$limit,
+					$offset,
+				],
 			),
 		);
-		// phpcs:enable
 
 		if ( ! \is_array( $rows ) ) {
 			return [];
@@ -87,12 +93,21 @@ class RevisionRepository {
 			return 0;
 		}
 
+		// Literal LIKE pattern; no user input to escape.
+		$autosave_like = '-autosave-%';
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation count; cached per-request.
 		$count = $wpdb->get_var(
-			"SELECT COUNT(DISTINCT r.post_parent)
-				FROM {$wpdb->posts} r
-				WHERE r.post_type = 'revision'
-					AND r.post_name NOT LIKE CONCAT(r.post_parent, '-autosave-%')",
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT r.post_parent)
+					FROM %i r
+					WHERE r.post_type = 'revision'
+						AND r.post_name NOT LIKE CONCAT(r.post_parent, %s)",
+				[
+					$wpdb->posts,
+					$autosave_like,
+				],
+			),
 		);
 
 		return (int) $count;
@@ -110,23 +125,25 @@ class RevisionRepository {
 			return [];
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders -- %d placeholders built from a fixed count of parent IDs.
-		$placeholders = \implode( ',', \array_fill( 0, \count( $parent_ids ), '%d' ) );
+		$placeholders = \implode( ', ', \array_fill( 0, \count( $parent_ids ), '%d' ) );
+		// Literal LIKE pattern; no user input to escape.
+		$autosave_like = '-autosave-%';
 
-		// Exclude autosaves so the count shown in paginated() matches what gets
-		// deleted by bulk actions. Autosave rows have post_name like '<id>-autosave-%'.
-		$query = \sprintf(
-			"SELECT ID FROM {$wpdb->posts}
-				WHERE post_type = 'revision'
-				AND post_parent IN (%s)
-				AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%%')",
-			$placeholders,
-		);
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- placeholders built above from a fixed count of trusted int IDs; values passed through wpdb::prepare.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- {$placeholders} is a fixed %d repeater; merged args feed wpdb::prepare.
 		$ids = $wpdb->get_col(
-			$wpdb->prepare( $query, ...$parent_ids ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->prepare(
+				"SELECT ID FROM %i
+					WHERE post_type = 'revision'
+					AND post_parent IN ({$placeholders})
+					AND post_name NOT LIKE CONCAT(post_parent, %s)",
+				\array_merge(
+					[ $wpdb->posts ],
+					$parent_ids,
+					[ $autosave_like ],
+				),
+			),
 		);
+		// phpcs:enable
 
 		if ( ! \is_array( $ids ) ) {
 			return [];

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Apermo\AdvancedRevisions\Revisions;
 
 /**
- * Aggregation queries for the Tools → Revisions overview.
+ * Runs aggregation queries for the Tools → Revisions overview.
  *
  * Queries are raw SQL on $wpdb->posts; they're purpose-built aggregates
  * (COUNT / MIN) that WP_Query can't express cleanly. The overview caches
@@ -71,7 +71,6 @@ class RevisionRepository {
 
 		$result = [];
 		foreach ( $rows as $row_data ) {
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- overview row shape.
 			$result[] = [
 				'id'         => (int) $row_data->ID,
 				'title'      => (string) $row_data->post_title,
@@ -85,7 +84,7 @@ class RevisionRepository {
 	}
 
 	/**
-	 * Total number of parent posts that have at least one revision — used for paginator.
+	 * Counts parent posts with at least one revision — used for paginator.
 	 */
 	public function total_parents(): int {
 		global $wpdb;

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -19,6 +19,15 @@ class RevisionRepository {
 	public const DEFAULT_PER_PAGE = 20;
 
 	/**
+	 * Parent post_status values the overview considers. Applied identically in
+	 * paginated() and total_parents() so the paginator denominator matches the
+	 * row query — orphan/trash/auto-draft parents are excluded from both.
+	 *
+	 * @var list<string>
+	 */
+	private const OVERVIEW_STATUSES = [ 'publish', 'draft', 'pending', 'private', 'future' ];
+
+	/**
 	 * Returns paginated rows for the overview table.
 	 *
 	 * Each row: parent post ID, title, type, author ID, revision count,
@@ -37,9 +46,14 @@ class RevisionRepository {
 		$limit  = \max( 1, \min( 500, $per_page ) );
 		$offset = \max( 0, ( $page - 1 ) * $limit );
 		// Literal LIKE pattern; no user input to escape.
-		$autosave_like = '-autosave-%';
+		$autosave_like    = '-autosave-%';
+		$status_in_clause = '(' . \implode( ',', \array_fill( 0, \count( self::OVERVIEW_STATUSES ), '%s' ) ) . ')';
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- direct aggregation is the purpose of this helper; callers cache.
+		// Non-aggregated p.* columns are listed in GROUP BY alongside p.ID so the
+		// query is portable to MySQL configurations with ONLY_FULL_GROUP_BY, which
+		// do not universally honor functional-dependency detection (MariaDB, older
+		// MySQL 5.7, managed hosts with custom sql_mode).
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- {$status_in_clause} is a fixed %s repeater over OVERVIEW_STATUSES; merged args feed wpdb::prepare.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT p.ID, p.post_title, p.post_type, p.post_author,
@@ -51,19 +65,18 @@ class RevisionRepository {
 					AND r.post_type = 'revision'
 					AND r.post_name NOT LIKE CONCAT(p.ID, %s)
 				WHERE p.post_type != 'revision'
-					AND p.post_status IN ('publish', 'draft', 'pending', 'private', 'future')
-				GROUP BY p.ID
+					AND p.post_status IN {$status_in_clause}
+				GROUP BY p.ID, p.post_title, p.post_type, p.post_author
 				ORDER BY revision_count DESC, p.ID ASC
 				LIMIT %d OFFSET %d",
-				[
-					$wpdb->posts,
-					$wpdb->posts,
-					$autosave_like,
-					$limit,
-					$offset,
-				],
+				\array_merge(
+					[ $wpdb->posts, $wpdb->posts, $autosave_like ],
+					self::OVERVIEW_STATUSES,
+					[ $limit, $offset ],
+				),
 			),
 		);
+		// phpcs:enable
 
 		if ( ! \is_array( $rows ) ) {
 			return [];
@@ -85,6 +98,11 @@ class RevisionRepository {
 
 	/**
 	 * Counts parent posts with at least one revision — used for paginator.
+	 *
+	 * Joins the parent row and mirrors paginated()'s post_type + post_status
+	 * filters so the paginator denominator matches the numerator: orphan
+	 * revisions (parent deleted) and parents in trash/auto-draft don't inflate
+	 * the page count.
 	 */
 	public function total_parents(): int {
 		global $wpdb;
@@ -93,21 +111,26 @@ class RevisionRepository {
 		}
 
 		// Literal LIKE pattern; no user input to escape.
-		$autosave_like = '-autosave-%';
+		$autosave_like    = '-autosave-%';
+		$status_in_clause = '(' . \implode( ',', \array_fill( 0, \count( self::OVERVIEW_STATUSES ), '%s' ) ) . ')';
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation count; cached per-request.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- {$status_in_clause} is a fixed %s repeater over OVERVIEW_STATUSES; merged args feed wpdb::prepare.
 		$count = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(DISTINCT r.post_parent)
 					FROM %i r
+					INNER JOIN %i p ON p.ID = r.post_parent
 					WHERE r.post_type = 'revision'
-						AND r.post_name NOT LIKE CONCAT(r.post_parent, %s)",
-				[
-					$wpdb->posts,
-					$autosave_like,
-				],
+						AND r.post_name NOT LIKE CONCAT(r.post_parent, %s)
+						AND p.post_type != 'revision'
+						AND p.post_status IN {$status_in_clause}",
+				\array_merge(
+					[ $wpdb->posts, $wpdb->posts, $autosave_like ],
+					self::OVERVIEW_STATUSES,
+				),
 			),
 		);
+		// phpcs:enable
 
 		return (int) $count;
 	}

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -113,8 +113,13 @@ class RevisionRepository {
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders -- %d placeholders built from a fixed count of parent IDs.
 		$placeholders = \implode( ',', \array_fill( 0, \count( $parent_ids ), '%d' ) );
 
+		// Exclude autosaves so the count shown in paginated() matches what gets
+		// deleted by bulk actions. Autosave rows have post_name like '<id>-autosave-%'.
 		$query = \sprintf(
-			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'revision' AND post_parent IN (%s)",
+			"SELECT ID FROM {$wpdb->posts}
+				WHERE post_type = 'revision'
+				AND post_parent IN (%s)
+				AND post_name NOT LIKE CONCAT(post_parent, '-autosave-%%')",
 			$placeholders,
 		);
 

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -19,7 +19,7 @@ class RevisionRepository {
 	public const DEFAULT_PER_PAGE = 20;
 
 	/**
-	 * Return paginated rows for the overview table.
+	 * Returns paginated rows for the overview table.
 	 *
 	 * Each row: parent post ID, title, type, author ID, revision count,
 	 * oldest revision GMT timestamp.
@@ -99,7 +99,7 @@ class RevisionRepository {
 	}
 
 	/**
-	 * Return every revision ID belonging to the given parent post IDs.
+	 * Returns every revision ID belonging to the given parent post IDs.
 	 *
 	 * @param array<int, int> $parent_ids Parent post IDs.
 	 * @return array<int, int> Revision IDs.

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Revisions;
+
+/**
+ * Aggregation queries for the Tools → Revisions overview.
+ *
+ * Queries are raw SQL on $wpdb->posts; they're purpose-built aggregates
+ * (COUNT / MIN) that WP_Query can't express cleanly. The overview caches
+ * the full page result set per request.
+ */
+class RevisionRepository {
+
+	/**
+	 * Default rows returned per page on the overview.
+	 */
+	public const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * Return paginated rows for the overview table.
+	 *
+	 * Each row: parent post ID, title, type, author ID, revision count,
+	 * oldest revision GMT timestamp.
+	 *
+	 * @param int $per_page Rows per page (clamped to [1, 500]).
+	 * @param int $page     1-based page number.
+	 * @return array<int, array{id:int, title:string, post_type:string, author:int, revisions:int, oldest_gmt:string}>
+	 */
+	public function paginated( int $per_page = self::DEFAULT_PER_PAGE, int $page = 1 ): array {
+		global $wpdb;
+		if ( ! isset( $wpdb ) ) {
+			return [];
+		}
+
+		$limit  = \max( 1, \min( 500, $per_page ) );
+		$offset = \max( 0, ( $page - 1 ) * $limit );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQLPlaceholders -- static LIKE pattern with CONCAT of parent ID (int); no user input.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT p.ID, p.post_title, p.post_type, p.post_author,
+					COUNT(r.ID) AS revision_count,
+					MIN(r.post_date_gmt) AS oldest_gmt
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->posts} r
+					ON r.post_parent = p.ID
+					AND r.post_type = 'revision'
+					AND r.post_name NOT LIKE CONCAT(p.ID, '-autosave-%')
+				WHERE p.post_type != 'revision'
+					AND p.post_status IN ('publish', 'draft', 'pending', 'private', 'future')
+				GROUP BY p.ID
+				ORDER BY revision_count DESC, p.ID ASC
+				LIMIT %d OFFSET %d",
+				$limit,
+				$offset,
+			),
+		);
+		// phpcs:enable
+
+		if ( ! \is_array( $rows ) ) {
+			return [];
+		}
+
+		$result = [];
+		foreach ( $rows as $row_data ) {
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- overview row shape.
+			$result[] = [
+				'id'         => (int) $row_data->ID,
+				'title'      => (string) $row_data->post_title,
+				'post_type'  => (string) $row_data->post_type,
+				'author'     => (int) $row_data->post_author,
+				'revisions'  => (int) $row_data->revision_count,
+				'oldest_gmt' => (string) $row_data->oldest_gmt,
+			];
+		}
+		return $result;
+	}
+
+	/**
+	 * Total number of parent posts that have at least one revision — used for paginator.
+	 */
+	public function total_parents(): int {
+		global $wpdb;
+		if ( ! isset( $wpdb ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- aggregation count; cached per-request.
+		$count = $wpdb->get_var(
+			"SELECT COUNT(DISTINCT r.post_parent)
+				FROM {$wpdb->posts} r
+				WHERE r.post_type = 'revision'
+					AND r.post_name NOT LIKE CONCAT(r.post_parent, '-autosave-%')",
+		);
+
+		return (int) $count;
+	}
+
+	/**
+	 * Return every revision ID belonging to the given parent post IDs.
+	 *
+	 * @param array<int, int> $parent_ids Parent post IDs.
+	 * @return array<int, int> Revision IDs.
+	 */
+	public function revision_ids_for_parents( array $parent_ids ): array {
+		global $wpdb;
+		if ( ! isset( $wpdb ) || $parent_ids === [] ) {
+			return [];
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders -- %d placeholders built from a fixed count of parent IDs.
+		$placeholders = \implode( ',', \array_fill( 0, \count( $parent_ids ), '%d' ) );
+
+		$query = \sprintf(
+			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'revision' AND post_parent IN (%s)",
+			$placeholders,
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- placeholders built above from a fixed count of trusted int IDs; values passed through wpdb::prepare.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare( $query, ...$parent_ids ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		);
+
+		if ( ! \is_array( $ids ) ) {
+			return [];
+		}
+
+		return \array_map( 'intval', $ids );
+	}
+}

--- a/src/Revisions/TaxonomyRegistrar.php
+++ b/src/Revisions/TaxonomyRegistrar.php
@@ -18,7 +18,7 @@ final class TaxonomyRegistrar {
 	public const NOTE_META      = '_advanced_revisions_note';
 
 	/**
-	 * Register the taxonomy, term meta, and post meta on init.
+	 * Registers the taxonomy, term meta, and post meta on init.
 	 */
 	public static function register(): void {
 		add_action( 'init', [ self::class, 'register_taxonomy' ] );
@@ -26,7 +26,7 @@ final class TaxonomyRegistrar {
 	}
 
 	/**
-	 * Register the custom taxonomy against the built-in `revision` post type.
+	 * Registers the custom taxonomy against the built-in `revision` post type.
 	 */
 	public static function register_taxonomy(): void {
 		register_taxonomy(
@@ -53,7 +53,7 @@ final class TaxonomyRegistrar {
 	}
 
 	/**
-	 * Register term meta for the `protected` flag and post meta for per-revision notes.
+	 * Registers term meta for the `protected` flag and post meta for per-revision notes.
 	 */
 	public static function register_meta(): void {
 		register_term_meta(

--- a/src/Revisions/TaxonomyRegistrar.php
+++ b/src/Revisions/TaxonomyRegistrar.php
@@ -32,7 +32,6 @@ final class TaxonomyRegistrar {
 		register_taxonomy(
 			self::TAXONOMY,
 			'revision',
-			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- register_taxonomy args are a WP API shape.
 			[
 				'public'            => false,
 				'show_ui'           => true,
@@ -80,13 +79,11 @@ final class TaxonomyRegistrar {
 	}
 
 	/**
-	 * Human-readable labels for the taxonomy.
+	 * Returns human-readable labels for the taxonomy.
 	 *
 	 * @return array<string, string>
 	 */
 	private static function labels(): array {
-		// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- these are UI labels, not SQL.
-		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- taxonomy labels are a WP API shape.
 		return [
 			'name'          => __( 'Revision Tags', 'advanced-revisions' ),
 			'singular_name' => __( 'Revision Tag', 'advanced-revisions' ),

--- a/src/Revisions/TaxonomyRegistrar.php
+++ b/src/Revisions/TaxonomyRegistrar.php
@@ -15,7 +15,6 @@ final class TaxonomyRegistrar {
 
 	public const TAXONOMY       = 'revision_tag';
 	public const PROTECTED_META = 'protected';
-	public const NOTE_META      = '_advanced_revisions_note';
 
 	/**
 	 * Registers the taxonomy, term meta, and post meta on init.
@@ -52,7 +51,7 @@ final class TaxonomyRegistrar {
 	}
 
 	/**
-	 * Registers term meta for the `protected` flag and post meta for per-revision notes.
+	 * Registers term meta for the `protected` flag.
 	 */
 	public static function register_meta(): void {
 		register_term_meta(
@@ -63,17 +62,6 @@ final class TaxonomyRegistrar {
 				'single'            => true,
 				'show_in_rest'      => true,
 				'sanitize_callback' => static fn( $value ): bool => (bool) $value,
-			],
-		);
-
-		register_post_meta(
-			'revision',
-			self::NOTE_META,
-			[
-				'type'              => 'string',
-				'single'            => true,
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
 			],
 		);
 	}

--- a/src/Revisions/TaxonomyRegistrar.php
+++ b/src/Revisions/TaxonomyRegistrar.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Revisions;
+
+/**
+ * Registers the `revision_tag` taxonomy against the `revision` post type plus
+ * its `protected` term-meta flag, and the per-revision note meta.
+ *
+ * Tags and the protection flag power {@see ProtectionService}, which every
+ * cleanup path (#3, #5, #6, #7) calls before deleting rows.
+ */
+final class TaxonomyRegistrar {
+
+	public const TAXONOMY       = 'revision_tag';
+	public const PROTECTED_META = 'protected';
+	public const NOTE_META      = '_advanced_revisions_note';
+
+	/**
+	 * Register the taxonomy, term meta, and post meta on init.
+	 */
+	public static function register(): void {
+		add_action( 'init', [ self::class, 'register_taxonomy' ] );
+		add_action( 'init', [ self::class, 'register_meta' ] );
+	}
+
+	/**
+	 * Register the custom taxonomy against the built-in `revision` post type.
+	 */
+	public static function register_taxonomy(): void {
+		register_taxonomy(
+			self::TAXONOMY,
+			'revision',
+			// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- register_taxonomy args are a WP API shape.
+			[
+				'public'            => false,
+				'show_ui'           => true,
+				'show_in_menu'      => false,
+				'show_admin_column' => false,
+				'show_in_rest'      => true,
+				'rewrite'           => false,
+				'hierarchical'      => false,
+				'labels'            => self::labels(),
+				'capabilities'      => [
+					'manage_terms' => 'manage_options',
+					'edit_terms'   => 'manage_options',
+					'delete_terms' => 'manage_options',
+					'assign_terms' => 'edit_others_posts',
+				],
+			],
+		);
+	}
+
+	/**
+	 * Register term meta for the `protected` flag and post meta for per-revision notes.
+	 */
+	public static function register_meta(): void {
+		register_term_meta(
+			self::TAXONOMY,
+			self::PROTECTED_META,
+			[
+				'type'              => 'boolean',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => static fn( $value ): bool => (bool) $value,
+			],
+		);
+
+		register_post_meta(
+			'revision',
+			self::NOTE_META,
+			[
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		);
+	}
+
+	/**
+	 * Human-readable labels for the taxonomy.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function labels(): array {
+		// phpcs:disable Apermo.WordPress.NoHardcodedTableNames.Found -- these are UI labels, not SQL.
+		// phpcs:ignore Apermo.DataStructures.ArrayComplexity.TooManyKeys -- taxonomy labels are a WP API shape.
+		return [
+			'name'          => __( 'Revision Tags', 'advanced-revisions' ),
+			'singular_name' => __( 'Revision Tag', 'advanced-revisions' ),
+			'search_items'  => __( 'Search Revision Tags', 'advanced-revisions' ),
+			'all_items'     => __( 'All Revision Tags', 'advanced-revisions' ),
+			'edit_item'     => __( 'Edit Revision Tag', 'advanced-revisions' ),
+			'update_item'   => __( 'Update Revision Tag', 'advanced-revisions' ),
+			'add_new_item'  => __( 'Add New Revision Tag', 'advanced-revisions' ),
+			'new_item_name' => __( 'New Revision Tag Name', 'advanced-revisions' ),
+			'menu_name'     => __( 'Revision Tags', 'advanced-revisions' ),
+		];
+	}
+}

--- a/tests/Fixtures/WpdbDouble.php
+++ b/tests/Fixtures/WpdbDouble.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Minimal $wpdb test double used by unit tests that exercise SQL-executing code.
+ *
+ * This file is excluded from PHPCS via phpcs.xml.dist; the relaxed style here
+ * keeps the wpdb API shape small and readable.
+ *
+ * @package Advanced_Revisions_Tests
+ */
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Fixtures;
+
+// phpcs:disable
+
+final class WpdbDouble {
+
+	public string $posts = 'wp_posts';
+
+	public array $next_results = [];
+
+	public int $next_var = 0;
+
+	public array $next_col = [];
+
+	public function prepare( string $query, mixed ...$args ): string {
+		unset( $args );
+		return $query;
+	}
+
+	public function get_results( string $query ): array {
+		unset( $query );
+		return $this->next_results;
+	}
+
+	public function get_var( string $query ): int {
+		unset( $query );
+		return $this->next_var;
+	}
+
+	public function get_col( string $query ): array {
+		unset( $query );
+		return $this->next_col;
+	}
+}

--- a/tests/Integration/ExampleIntegrationTest.php
+++ b/tests/Integration/ExampleIntegrationTest.php
@@ -22,7 +22,7 @@ class ExampleIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The plugin or theme is active.
+	 * Verifies the plugin or theme is active.
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -80,6 +80,82 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
+	 * The add_widget helper registers the widget when capability passes.
+	 */
+	public function test_add_widget_registers_when_capable(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( '__' )->returnArg();
+		$called = false;
+		Functions\when( 'wp_add_dashboard_widget' )->alias(
+			static function () use ( &$called ): void {
+				$called = true;
+			},
+		);
+
+		DashboardWidget::add_widget();
+
+		self::assertTrue( $called );
+	}
+
+	/**
+	 * Empty-state copy is emitted when no revisions exist.
+	 */
+	public function test_render_empty_state(): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'get_transient' )->justReturn(
+			[
+				'total'     => 0,
+				'est_bytes' => 0,
+				'top'       => [],
+			],
+		);
+
+		\ob_start();
+		DashboardWidget::render();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'No stored revisions', $output );
+	}
+
+	/**
+	 * Populated stats render revision totals and the top-posts list.
+	 */
+	public function test_render_populated_stats(): void {
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'number_format_i18n' )->returnArg();
+		Functions\when( 'size_format' )->returnArg();
+		Functions\when( '_n' )->alias(
+			static fn( string $single, string $plural, int $count ): string => $count === 1 ? $single : $plural,
+		);
+		Functions\when( 'get_transient' )->justReturn(
+			[
+				'total'     => 42,
+				'est_bytes' => 1024,
+				'top'       => [
+					[
+						'title' => 'About',
+						'count' => 10,
+					],
+					[
+						'title' => 'Contact',
+						'count' => 5,
+					],
+				],
+			],
+		);
+
+		\ob_start();
+		DashboardWidget::render();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'About', $output );
+		self::assertStringContainsString( 'Contact', $output );
+	}
+
+	/**
 	 * Malformed cached data (missing keys) is treated as a miss.
 	 */
 	public function test_stats_treats_malformed_cache_as_miss(): void {

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -131,6 +131,7 @@ final class DashboardWidgetTest extends TestCase {
 		Functions\when( '_n' )->alias(
 			static fn( string $single, string $plural, int $count ): string => $count === 1 ? $single : $plural,
 		);
+		Functions\when( 'wp_kses' )->returnArg();
 		Functions\when( 'get_transient' )->justReturn(
 			[
 				'total'     => 42,

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Admin;
+
+use Apermo\AdvancedRevisions\Admin\DashboardWidget;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for DashboardWidget — focus on caching behavior and hook wiring.
+ */
+final class DashboardWidgetTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey and stubs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Registering hooks into wp_dashboard_setup.
+	 */
+	public function test_register_hooks_wp_dashboard_setup(): void {
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'wp_dashboard_setup', [ DashboardWidget::class, 'add_widget' ] );
+
+		DashboardWidget::register();
+	}
+
+	/**
+	 * Adding the widget is capability-gated; low-privilege users see nothing.
+	 */
+	public function test_add_widget_is_gated_by_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+		Functions\expect( 'wp_add_dashboard_widget' )->never();
+
+		DashboardWidget::add_widget();
+	}
+
+	/**
+	 * Cached transients short-circuit the expensive compute path.
+	 */
+	public function test_stats_returns_cached_transient_when_present(): void {
+		$cached = [
+			'total'     => 42,
+			'est_bytes' => 1024,
+			'top'       => [],
+		];
+		Functions\when( 'get_transient' )->justReturn( $cached );
+		Functions\expect( 'set_transient' )->never();
+
+		$result = DashboardWidget::stats();
+
+		self::assertSame( $cached, $result );
+	}
+
+	/**
+	 * Flushing deletes the cache transient.
+	 */
+	public function test_flush_deletes_the_transient(): void {
+		Functions\expect( 'delete_transient' )
+			->once()
+			->with( DashboardWidget::TRANSIENT_KEY );
+
+		DashboardWidget::flush();
+	}
+
+	/**
+	 * Malformed cached data (missing keys) is treated as a miss.
+	 */
+	public function test_stats_treats_malformed_cache_as_miss(): void {
+		Functions\when( 'get_transient' )->justReturn( [ 'total' => 10 ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		// Force $wpdb to null so compute() returns zeros rather than hitting the DB.
+		unset( $GLOBALS['wpdb'] );
+
+		$result = DashboardWidget::stats();
+
+		self::assertSame(
+			[
+				'total'     => 0,
+				'est_bytes' => 0,
+				'top'       => [],
+			],
+			$result,
+		);
+	}
+}

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -23,10 +23,11 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Tears down Brain Monkey.
+	 * Tears down Brain Monkey and clears $wpdb.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
+		unset( $GLOBALS['wpdb'] );
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 final class DashboardWidgetTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey and stubs.
+	 * Sets up Brain Monkey and stubs.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -23,7 +23,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/tests/Unit/Admin/DashboardWidgetTest.php
+++ b/tests/Unit/Admin/DashboardWidgetTest.php
@@ -32,7 +32,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Registering hooks into wp_dashboard_setup.
+	 * Verifies register() wires a wp_dashboard_setup hook.
 	 */
 	public function test_register_hooks_wp_dashboard_setup(): void {
 		Functions\expect( 'add_action' )
@@ -43,7 +43,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Adding the widget is capability-gated; low-privilege users see nothing.
+	 * Asserts adding the widget is capability-gated; low-privilege users see nothing.
 	 */
 	public function test_add_widget_is_gated_by_capability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
@@ -53,7 +53,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Cached transients short-circuit the expensive compute path.
+	 * Asserts cached transients short-circuit the expensive compute path.
 	 */
 	public function test_stats_returns_cached_transient_when_present(): void {
 		$cached = [
@@ -70,7 +70,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Flushing deletes the cache transient.
+	 * Asserts flushing deletes the cache transient.
 	 */
 	public function test_flush_deletes_the_transient(): void {
 		Functions\expect( 'delete_transient' )
@@ -81,7 +81,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * The add_widget helper registers the widget when capability passes.
+	 * Asserts the add_widget helper registers the widget when capability passes.
 	 */
 	public function test_add_widget_registers_when_capable(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
@@ -99,7 +99,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Empty-state copy is emitted when no revisions exist.
+	 * Asserts empty-state copy is emitted when no revisions exist.
 	 */
 	public function test_render_empty_state(): void {
 		Functions\when( '__' )->returnArg();
@@ -120,7 +120,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Populated stats render revision totals and the top-posts list.
+	 * Asserts populated stats render revision totals and the top-posts list.
 	 */
 	public function test_render_populated_stats(): void {
 		Functions\when( '__' )->returnArg();
@@ -157,7 +157,7 @@ final class DashboardWidgetTest extends TestCase {
 	}
 
 	/**
-	 * Malformed cached data (missing keys) is treated as a miss.
+	 * Asserts malformed cached data (missing keys) is treated as a miss.
 	 */
 	public function test_stats_treats_malformed_cache_as_miss(): void {
 		Functions\when( 'get_transient' )->justReturn( [ 'total' => 10 ] );

--- a/tests/Unit/Admin/OverviewPageTest.php
+++ b/tests/Unit/Admin/OverviewPageTest.php
@@ -56,7 +56,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * Registering hooks admin_menu and admin_post_*.
+	 * Verifies register() wires admin_menu and admin_post_* hooks.
 	 */
 	public function test_register_hooks_admin_menu_and_admin_post(): void {
 		Functions\expect( 'add_action' )->times( 2 );
@@ -65,7 +65,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * The add_page helper mounts the page under Tools.
+	 * Verifies the add_page helper mounts the page under Tools.
 	 */
 	public function test_add_page_registers_under_tools(): void {
 		$captured = [];
@@ -79,11 +79,11 @@ final class OverviewPageTest extends TestCase {
 		OverviewPage::add_page();
 
 		self::assertSame( OverviewPage::MENU_SLUG, $captured[3] );
-		self::assertSame( OverviewPage::CAPABILITY, $captured[2] );
+		self::assertSame( OverviewPage::REQUIRED_CAPABILITY, $captured[2] );
 	}
 
 	/**
-	 * The render method returns silently when the user lacks capability.
+	 * Asserts render() returns silently when the user lacks capability.
 	 */
 	public function test_render_bails_without_capability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
@@ -96,7 +96,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * Empty-state render emits the no-revisions message.
+	 * Verifies that the empty-state render emits the no-revisions message.
 	 */
 	public function test_render_shows_empty_state_when_no_rows(): void {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- test-local wpdb stub.
@@ -111,7 +111,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * The bulk-post handler exits via wp_die on missing capability.
+	 * Asserts the bulk-post handler exits via wp_die on missing capability.
 	 */
 	public function test_handle_bulk_post_dies_without_capability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
@@ -134,7 +134,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * Full render path with rows and pagination covers render_form + render_row.
+	 * Covers render_form + render_row via the full render path with rows and pagination.
 	 */
 	public function test_render_full_table_with_rows(): void {
 		// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
@@ -195,7 +195,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * The bulk-post handler redirects with ar_bulk=empty when no selection.
+	 * Verifies the bulk-post handler redirects with ar_bulk=empty on no selection.
 	 */
 	public function test_handle_bulk_post_redirects_on_empty_selection(): void {
 		$_POST = [

--- a/tests/Unit/Admin/OverviewPageTest.php
+++ b/tests/Unit/Admin/OverviewPageTest.php
@@ -45,12 +45,13 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * Tears down Brain Monkey and clears superglobals.
+	 * Tears down Brain Monkey and clears superglobals so tests can't leak state.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
 		$_POST = [];
 		$_GET  = [];
+		unset( $GLOBALS['wpdb'] );
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Admin/OverviewPageTest.php
+++ b/tests/Unit/Admin/OverviewPageTest.php
@@ -18,7 +18,7 @@ use stdClass;
 final class OverviewPageTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey and default WP function stubs.
+	 * Sets up Brain Monkey and default WP function stubs.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -45,7 +45,7 @@ final class OverviewPageTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey and clear superglobals.
+	 * Tears down Brain Monkey and clears superglobals.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/tests/Unit/Admin/OverviewPageTest.php
+++ b/tests/Unit/Admin/OverviewPageTest.php
@@ -33,6 +33,9 @@ final class OverviewPageTest extends TestCase {
 		Functions\when( 'sanitize_text_field' )->returnArg();
 		Functions\when( 'wp_unslash' )->returnArg();
 		Functions\when( 'current_user_can' )->justReturn( true );
+		// required_capability() runs apply_filters; return the default value
+		// unchanged so tests exercise the realistic path.
+		Functions\when( 'apply_filters' )->returnArg( 2 );
 		Functions\when( 'admin_url' )->alias(
 			static fn( string $path = '' ): string => '/wp-admin/' . $path,
 		);
@@ -202,15 +205,51 @@ final class OverviewPageTest extends TestCase {
 			OverviewPage::NONCE_NAME => 'valid',
 		];
 		Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
-		$redirected_to = '';
+		// wp_safe_redirect() is followed by exit; throwing from the stub
+		// short-circuits that exit the same way the live request would end.
 		Functions\when( 'wp_safe_redirect' )->alias(
-			static function ( string $url ) use ( &$redirected_to ): void {
-				$redirected_to = $url;
+			static function ( string $url ): void {
+				throw new RuntimeException( $url ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- test-only rethrow carrying the redirect URL for assertions.
 			},
 		);
 
-		OverviewPage::handle_bulk_post();
+		try {
+			OverviewPage::handle_bulk_post();
+			self::fail( 'Expected wp_safe_redirect to short-circuit via exception.' );
+		} catch ( RuntimeException $redirect ) {
+			self::assertStringContainsString( 'ar_bulk=empty', $redirect->getMessage() );
+		}
+	}
 
-		self::assertStringContainsString( 'ar_bulk=empty', $redirected_to );
+	/**
+	 * Verifies the bulk-post handler drops unauthorized parents and reports
+	 * the denied count instead of deleting their revisions.
+	 */
+	public function test_handle_bulk_post_skips_unauthorized_parents(): void {
+		$_POST = [
+			OverviewPage::NONCE_NAME => 'valid',
+			'ar_parent_ids'          => [ '42', '99' ],
+		];
+		Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+		// The setUp() blanket `current_user_can → true` still authorizes
+		// access to the overview page; here we deny every per-parent
+		// edit_post check so both IDs fall into the `denied` bucket and
+		// the handler bails before running the deleter.
+		Functions\when( 'current_user_can' )->alias(
+			static fn( string $cap ): bool => $cap !== 'edit_post',
+		);
+		Functions\when( 'wp_safe_redirect' )->alias(
+			static function ( string $url ): void {
+				throw new RuntimeException( $url ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- test-only rethrow carrying the redirect URL for assertions.
+			},
+		);
+
+		try {
+			OverviewPage::handle_bulk_post();
+			self::fail( 'Expected redirect.' );
+		} catch ( RuntimeException $redirect ) {
+			self::assertStringContainsString( 'ar_denied=2', $redirect->getMessage() );
+			self::assertStringNotContainsString( 'ar_deleted=', $redirect->getMessage() );
+		}
 	}
 }

--- a/tests/Unit/Admin/OverviewPageTest.php
+++ b/tests/Unit/Admin/OverviewPageTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Admin;
+
+use Apermo\AdvancedRevisions\Admin\OverviewPage;
+use Apermo\AdvancedRevisions\Tests\Fixtures\WpdbDouble;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+/**
+ * Tests for OverviewPage — hook wiring, request parsing, and render paths.
+ */
+final class OverviewPageTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey and default WP function stubs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'sanitize_key' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'admin_url' )->alias(
+			static fn( string $path = '' ): string => '/wp-admin/' . $path,
+		);
+		Functions\when( 'add_query_arg' )->alias(
+			static fn( array $args, string $url ): string => $url . '?' . \http_build_query( $args ),
+		);
+		Functions\when( 'get_edit_post_link' )->justReturn( '/wp-admin/edit.php?post=42' );
+		Functions\when( 'wp_nonce_field' )->justReturn( '' );
+		Functions\when( 'wp_admin_notice' )->justReturn( '' );
+	}
+
+	/**
+	 * Tear down Brain Monkey and clear superglobals.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		$_POST = [];
+		$_GET  = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Registering hooks admin_menu and admin_post_*.
+	 */
+	public function test_register_hooks_admin_menu_and_admin_post(): void {
+		Functions\expect( 'add_action' )->times( 2 );
+
+		OverviewPage::register();
+	}
+
+	/**
+	 * The add_page helper mounts the page under Tools.
+	 */
+	public function test_add_page_registers_under_tools(): void {
+		$captured = [];
+		Functions\when( 'add_management_page' )->alias(
+			static function ( string $title, string $menu, string $cap, string $slug, $cb ) use ( &$captured ): void {
+				unset( $cb );
+				$captured = [ $title, $menu, $cap, $slug ];
+			},
+		);
+
+		OverviewPage::add_page();
+
+		self::assertSame( OverviewPage::MENU_SLUG, $captured[3] );
+		self::assertSame( OverviewPage::CAPABILITY, $captured[2] );
+	}
+
+	/**
+	 * The render method returns silently when the user lacks capability.
+	 */
+	public function test_render_bails_without_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		\ob_start();
+		OverviewPage::render();
+		$output = (string) \ob_get_clean();
+
+		self::assertSame( '', $output );
+	}
+
+	/**
+	 * Empty-state render emits the no-revisions message.
+	 */
+	public function test_render_shows_empty_state_when_no_rows(): void {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- test-local wpdb stub.
+		$GLOBALS['wpdb'] = new WpdbDouble();
+
+		\ob_start();
+		OverviewPage::render();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'No posts', $output );
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/**
+	 * The bulk-post handler exits via wp_die on missing capability.
+	 */
+	public function test_handle_bulk_post_dies_without_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+		$died = false;
+		Functions\when( 'wp_die' )->alias(
+			static function () use ( &$died ): void {
+				$died = true;
+				throw new RuntimeException( 'died' );
+			},
+		);
+
+		try {
+			OverviewPage::handle_bulk_post();
+		} catch ( RuntimeException $error ) {
+			// Expected: wp_die() throws in our stub.
+			unset( $error );
+		}
+
+		self::assertTrue( $died );
+	}
+
+	/**
+	 * Full render path with rows and pagination covers render_form + render_row.
+	 */
+	public function test_render_full_table_with_rows(): void {
+		// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+		$row_data                 = new stdClass();
+		$row_data->ID             = 42;
+		$row_data->post_title     = 'Hello';
+		$row_data->post_type      = 'post';
+		$row_data->post_author    = 1;
+		$row_data->revision_count = 10;
+		$row_data->oldest_gmt     = '2024-01-01';
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- test-local wpdb stub.
+		$GLOBALS['wpdb']               = new WpdbDouble();
+		$GLOBALS['wpdb']->next_results = [ $row_data ];
+		$GLOBALS['wpdb']->next_var     = 60;
+
+		\ob_start();
+		OverviewPage::render();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( 'Hello', $output );
+		self::assertStringContainsString( '<table', $output );
+		self::assertStringContainsString( 'ar_parent_ids', $output );
+		self::assertStringContainsString( 'tablenav-pages', $output );
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/**
+	 * Success notice is rendered when ar_bulk=done is in the query string.
+	 */
+	public function test_render_notices_shows_success_after_bulk_delete(): void {
+		$_GET = [
+			'ar_bulk'    => 'done',
+			'ar_deleted' => '3',
+			'ar_skipped' => '1',
+		];
+
+		$notices = [];
+		Functions\when( 'wp_admin_notice' )->alias(
+			static function ( string $message, array $args ) use ( &$notices ): void {
+				$notices[] = [
+					'message' => $message,
+					'args' => $args,
+				];
+			},
+		);
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- test-local wpdb stub.
+		$GLOBALS['wpdb'] = new WpdbDouble();
+
+		\ob_start();
+		OverviewPage::render();
+		\ob_end_clean();
+
+		self::assertCount( 1, $notices );
+		self::assertSame( 'success', $notices[0]['args']['type'] );
+		unset( $GLOBALS['wpdb'] );
+	}
+
+	/**
+	 * The bulk-post handler redirects with ar_bulk=empty when no selection.
+	 */
+	public function test_handle_bulk_post_redirects_on_empty_selection(): void {
+		$_POST = [
+			OverviewPage::NONCE_NAME => 'valid',
+		];
+		Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+		$redirected_to = '';
+		Functions\when( 'wp_safe_redirect' )->alias(
+			static function ( string $url ) use ( &$redirected_to ): void {
+				$redirected_to = $url;
+			},
+		);
+
+		OverviewPage::handle_bulk_post();
+
+		self::assertStringContainsString( 'ar_bulk=empty', $redirected_to );
+	}
+}

--- a/tests/Unit/Admin/PostListColumnTest.php
+++ b/tests/Unit/Admin/PostListColumnTest.php
@@ -53,7 +53,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * The add_column helper appends when no 'date' column exists.
+	 * Asserts the add_column helper appends when no 'date' column exists.
 	 */
 	public function test_add_column_appends_when_date_absent(): void {
 		$columns = [
@@ -71,7 +71,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * The add_column helper inserts immediately after 'date' when present.
+	 * Asserts the add_column helper inserts immediately after 'date' when present.
 	 */
 	public function test_add_column_inserts_after_date(): void {
 		$columns = [
@@ -89,7 +89,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * Row action is skipped for posts with zero revisions so the row stays clean.
+	 * Asserts the row action is skipped for posts with zero revisions so the row stays clean.
 	 */
 	public function test_add_row_action_skips_zero_count_posts(): void {
 		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
@@ -104,7 +104,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * Row action appends the Manage revisions link when the count is positive.
+	 * Asserts the row action appends the Manage revisions link when the count is positive.
 	 */
 	public function test_add_row_action_appends_link_when_revisions_exist(): void {
 		// Inject a non-zero count without running SQL by priming the cache
@@ -123,7 +123,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * The compare_url helper links to revision.php with a real revision ID.
+	 * Asserts the compare_url helper links to revision.php with a real revision ID.
 	 */
 	public function test_compare_url_builds_admin_revision_php_url(): void {
 		$revision     = new WP_Post();
@@ -137,7 +137,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * The count_for helper returns 0 when no count is cached for a post.
+	 * Asserts the count_for helper returns 0 when no count is cached for a post.
 	 */
 	public function test_count_for_returns_zero_when_unknown(): void {
 		// Isolate: ensure no $wpdb is leaking across tests.

--- a/tests/Unit/Admin/PostListColumnTest.php
+++ b/tests/Unit/Admin/PostListColumnTest.php
@@ -18,7 +18,7 @@ use WP_Post;
 final class PostListColumnTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey + reset the per-request cache.
+	 * Sets up Brain Monkey + reset the per-request cache.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,7 +43,7 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey + reset cache.
+	 * Tears down Brain Monkey + reset cache.
 	 */
 	protected function tearDown(): void {
 		PostListColumn::reset_cache();

--- a/tests/Unit/Admin/PostListColumnTest.php
+++ b/tests/Unit/Admin/PostListColumnTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Admin;
+
+use Apermo\AdvancedRevisions\Admin\PostListColumn;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use WP_Post;
+
+/**
+ * Tests for PostListColumn — focus on the column insertion logic, row-action
+ * assembly, and URL building. SQL aggregation is exercised in integration.
+ */
+final class PostListColumnTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey + reset the per-request cache.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		PostListColumn::reset_cache();
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_url' )->returnArg();
+	}
+
+	/**
+	 * Tear down Brain Monkey + reset cache.
+	 */
+	protected function tearDown(): void {
+		PostListColumn::reset_cache();
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * The add_column helper appends when no 'date' column exists.
+	 */
+	public function test_add_column_appends_when_date_absent(): void {
+		$columns = [
+			'cb'    => '<input />',
+			'title' => 'Title',
+		];
+
+		$result = PostListColumn::add_column( $columns );
+
+		self::assertArrayHasKey( PostListColumn::COLUMN_KEY, $result );
+		self::assertSame(
+			[ 'cb', 'title', PostListColumn::COLUMN_KEY ],
+			\array_keys( $result ),
+		);
+	}
+
+	/**
+	 * The add_column helper inserts immediately after 'date' when present.
+	 */
+	public function test_add_column_inserts_after_date(): void {
+		$columns = [
+			'cb'    => '<input />',
+			'title' => 'Title',
+			'date'  => 'Date',
+		];
+
+		$result = PostListColumn::add_column( $columns );
+
+		self::assertSame(
+			[ 'cb', 'title', 'date', PostListColumn::COLUMN_KEY ],
+			\array_keys( $result ),
+		);
+	}
+
+	/**
+	 * Row action is skipped for posts with zero revisions so the row stays clean.
+	 */
+	public function test_add_row_action_skips_zero_count_posts(): void {
+		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
+		Functions\when( 'add_query_arg' )->justReturn( 'https://example.tld/wp-admin/revision.php?from=42&to=42' );
+
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		$actions = PostListColumn::add_row_action( [ 'edit' => 'Edit' ], $post );
+
+		self::assertSame( [ 'edit' => 'Edit' ], $actions );
+	}
+
+	/**
+	 * Row action appends the Manage revisions link when the count is positive.
+	 */
+	public function test_add_row_action_appends_link_when_revisions_exist(): void {
+		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
+		Functions\when( 'add_query_arg' )->justReturn( 'https://example.tld/wp-admin/revision.php?from=42&to=42' );
+		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+
+		// Inject a non-zero count without running SQL by priming the cache
+		// via reflection of the static property.
+		$reflection = new ReflectionClass( PostListColumn::class );
+		$prop       = $reflection->getProperty( 'counts' );
+		$prop->setValue( null, [ 42 => 7 ] );
+
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		$actions = PostListColumn::add_row_action( [ 'edit' => 'Edit' ], $post );
+
+		self::assertArrayHasKey( 'advanced_revisions_manage', $actions );
+		self::assertStringContainsString( 'Manage revisions', $actions['advanced_revisions_manage'] );
+	}
+
+	/**
+	 * The compare_url helper composes the expected admin URL with from/to args.
+	 */
+	public function test_compare_url_builds_admin_revision_php_url(): void {
+		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
+		Functions\when( 'add_query_arg' )->alias(
+			static function ( array $args, string $url ): string {
+				return $url . '?' . \http_build_query( $args );
+			},
+		);
+
+		$url = PostListColumn::compare_url( 42 );
+
+		self::assertStringContainsString( 'revision.php', $url );
+		self::assertStringContainsString( 'from=42', $url );
+		self::assertStringContainsString( 'to=42', $url );
+	}
+
+	/**
+	 * The count_for helper returns 0 when no count is cached for a post.
+	 */
+	public function test_count_for_returns_zero_when_unknown(): void {
+		// Isolate: ensure no $wpdb is leaking across tests.
+		unset( $GLOBALS['wpdb'] );
+
+		self::assertSame( 0, PostListColumn::count_for( 999 ) );
+	}
+}

--- a/tests/Unit/Admin/PostListColumnTest.php
+++ b/tests/Unit/Admin/PostListColumnTest.php
@@ -43,10 +43,11 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * Tears down Brain Monkey + reset cache.
+	 * Tears down Brain Monkey, resets cache, and clears $wpdb.
 	 */
 	protected function tearDown(): void {
 		PostListColumn::reset_cache();
+		unset( $GLOBALS['wpdb'] );
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/Unit/Admin/PostListColumnTest.php
+++ b/tests/Unit/Admin/PostListColumnTest.php
@@ -29,6 +29,17 @@ final class PostListColumnTest extends TestCase {
 		Functions\when( 'esc_html' )->returnArg();
 		Functions\when( 'esc_html__' )->returnArg();
 		Functions\when( 'esc_url' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'wp_get_post_revisions' )->justReturn( [] );
+		Functions\when( 'get_edit_post_link' )->justReturn( '' );
+		Functions\when( 'admin_url' )->alias(
+			static fn( string $path = '' ): string => 'https://example.tld/wp-admin/' . $path,
+		);
+		Functions\when( 'add_query_arg' )->alias(
+			static function ( array $args, string $url ): string {
+				return $url . '?' . \http_build_query( $args );
+			},
+		);
 	}
 
 	/**
@@ -95,11 +106,6 @@ final class PostListColumnTest extends TestCase {
 	 * Row action appends the Manage revisions link when the count is positive.
 	 */
 	public function test_add_row_action_appends_link_when_revisions_exist(): void {
-		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
-		Functions\when( 'add_query_arg' )->justReturn( 'https://example.tld/wp-admin/revision.php?from=42&to=42' );
-		Functions\when( 'esc_url' )->returnArg();
-		Functions\when( 'esc_html__' )->returnArg();
-
 		// Inject a non-zero count without running SQL by priming the cache
 		// via reflection of the static property.
 		$reflection = new ReflectionClass( PostListColumn::class );
@@ -116,21 +122,17 @@ final class PostListColumnTest extends TestCase {
 	}
 
 	/**
-	 * The compare_url helper composes the expected admin URL with from/to args.
+	 * The compare_url helper links to revision.php with a real revision ID.
 	 */
 	public function test_compare_url_builds_admin_revision_php_url(): void {
-		Functions\when( 'admin_url' )->justReturn( 'https://example.tld/wp-admin/revision.php' );
-		Functions\when( 'add_query_arg' )->alias(
-			static function ( array $args, string $url ): string {
-				return $url . '?' . \http_build_query( $args );
-			},
-		);
+		$revision     = new WP_Post();
+		$revision->ID = 9001;
+		Functions\when( 'wp_get_post_revisions' )->justReturn( [ $revision ] );
 
 		$url = PostListColumn::compare_url( 42 );
 
 		self::assertStringContainsString( 'revision.php', $url );
-		self::assertStringContainsString( 'from=42', $url );
-		self::assertStringContainsString( 'to=42', $url );
+		self::assertStringContainsString( 'revision=9001', $url );
 	}
 
 	/**

--- a/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
+++ b/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
@@ -31,7 +31,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	private array $deleted_meta = [];
 
 	/**
-	 * Set up Brain Monkey and default WP function stubs.
+	 * Sets up Brain Monkey and default WP function stubs.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -68,7 +68,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
+++ b/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
@@ -77,7 +77,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Registering hooks add_meta_boxes, save_post, and init.
+	 * Verifies register() wires add_meta_boxes, save_post, and init hooks.
 	 */
 	public function test_register_hooks_three_actions(): void {
 		Functions\expect( 'add_action' )
@@ -87,7 +87,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Meta registration runs for each revisable post type.
+	 * Asserts meta registration runs for each revisable post type.
 	 */
 	public function test_register_post_meta_runs_for_each_type(): void {
 		$registrations = [];
@@ -104,7 +104,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Meta box is added for each revisable post type.
+	 * Asserts the meta box is added for each revisable post type.
 	 */
 	public function test_add_meta_box_runs_for_each_type(): void {
 		$calls = [];
@@ -121,7 +121,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Rendering emits the nonce field and input markup.
+	 * Asserts rendering emits the nonce field and input markup.
 	 */
 	public function test_render_emits_expected_markup(): void {
 		$post     = new WP_Post();
@@ -136,7 +136,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Save bails on missing nonce.
+	 * Asserts save() bails on missing nonce.
 	 */
 	public function test_save_bails_without_nonce(): void {
 		$_POST = [];
@@ -148,7 +148,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Save deletes meta when the submitted value is blank.
+	 * Asserts save() deletes meta when the submitted value is blank.
 	 */
 	public function test_save_deletes_meta_on_blank_value(): void {
 		$_POST = [
@@ -164,7 +164,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Save writes meta when the submitted value is a valid number.
+	 * Asserts save() writes meta when the submitted value is a valid number.
 	 */
 	public function test_save_writes_meta_when_value_present(): void {
 		$_POST = [
@@ -181,7 +181,7 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Save clamps values below -1.
+	 * Asserts save() clamps values below -1.
 	 */
 	public function test_save_clamps_below_minus_one(): void {
 		$_POST = [

--- a/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
+++ b/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Admin;
+
+use Apermo\AdvancedRevisions\Admin\RevisionLimitMetaBox;
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Tests for RevisionLimitMetaBox — hooks, register_post_meta, save flow.
+ */
+final class RevisionLimitMetaBoxTest extends TestCase {
+
+	/**
+	 * Captured update_post_meta calls.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $updated_meta = [];
+
+	/**
+	 * Captured delete_post_meta keys.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $deleted_meta = [];
+
+	/**
+	 * Set up Brain Monkey and default WP function stubs.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		$this->updated_meta = [];
+		$this->deleted_meta = [];
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'esc_attr' )->returnArg();
+		Functions\when( 'get_post_types' )->justReturn( [ 'post', 'page' ] );
+		Functions\when( 'post_type_supports' )->justReturn( true );
+		Functions\when( 'get_post_meta' )->justReturn( '' );
+		Functions\when( 'update_post_meta' )->alias(
+			function ( int $id, string $key, int $value ): void {
+				$this->updated_meta[] = [
+					'id'    => $id,
+					'key'   => $key,
+					'value' => $value,
+				];
+			},
+		);
+		Functions\when( 'delete_post_meta' )->alias(
+			function ( int $id, string $key ): void {
+				$this->deleted_meta[] = $key;
+				unset( $id );
+			},
+		);
+		Functions\when( 'wp_verify_nonce' )->justReturn( 1 );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'wp_nonce_field' )->justReturn( '' );
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Registering hooks add_meta_boxes, save_post, and init.
+	 */
+	public function test_register_hooks_three_actions(): void {
+		Functions\expect( 'add_action' )
+			->times( 3 );
+
+		RevisionLimitMetaBox::register();
+	}
+
+	/**
+	 * Meta registration runs for each revisable post type.
+	 */
+	public function test_register_post_meta_runs_for_each_type(): void {
+		$registrations = [];
+		Functions\when( 'register_post_meta' )->alias(
+			static function ( string $type, string $key, array $args ) use ( &$registrations ): void {
+				$registrations[] = $type;
+				unset( $key, $args );
+			},
+		);
+
+		RevisionLimitMetaBox::register_post_meta();
+
+		self::assertSame( [ 'post', 'page' ], $registrations );
+	}
+
+	/**
+	 * Meta box is added for each revisable post type.
+	 */
+	public function test_add_meta_box_runs_for_each_type(): void {
+		$calls = [];
+		Functions\when( 'add_meta_box' )->alias(
+			static function ( string $id, string $title, $callback, string $screen ) use ( &$calls ): void {
+				unset( $id, $title, $callback );
+				$calls[] = $screen;
+			},
+		);
+
+		RevisionLimitMetaBox::add_meta_box();
+
+		self::assertSame( [ 'post', 'page' ], $calls );
+	}
+
+	/**
+	 * Rendering emits the nonce field and input markup.
+	 */
+	public function test_render_emits_expected_markup(): void {
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		\ob_start();
+		RevisionLimitMetaBox::render( $post );
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( '<input type="number"', $output );
+		self::assertStringContainsString( LimitService::PER_POST_META_KEY, $output );
+	}
+
+	/**
+	 * Save bails on missing nonce.
+	 */
+	public function test_save_bails_without_nonce(): void {
+		$_POST = [];
+		$post  = new WP_Post();
+
+		RevisionLimitMetaBox::save( 42, $post );
+
+		self::assertSame( [], $this->updated_meta );
+	}
+
+	/**
+	 * Save deletes meta when the submitted value is blank.
+	 */
+	public function test_save_deletes_meta_on_blank_value(): void {
+		$_POST = [
+			RevisionLimitMetaBox::NONCE_NAME => 'abc',
+			LimitService::PER_POST_META_KEY  => '',
+		];
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		RevisionLimitMetaBox::save( 42, $post );
+
+		self::assertSame( [ LimitService::PER_POST_META_KEY ], $this->deleted_meta );
+	}
+
+	/**
+	 * Save writes meta when the submitted value is a valid number.
+	 */
+	public function test_save_writes_meta_when_value_present(): void {
+		$_POST = [
+			RevisionLimitMetaBox::NONCE_NAME => 'abc',
+			LimitService::PER_POST_META_KEY  => '7',
+		];
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		RevisionLimitMetaBox::save( 42, $post );
+
+		self::assertCount( 1, $this->updated_meta );
+		self::assertSame( 7, $this->updated_meta[0]['value'] );
+	}
+
+	/**
+	 * Save clamps values below -1.
+	 */
+	public function test_save_clamps_below_minus_one(): void {
+		$_POST = [
+			RevisionLimitMetaBox::NONCE_NAME => 'abc',
+			LimitService::PER_POST_META_KEY  => '-99',
+		];
+		$post     = new WP_Post();
+		$post->ID = 42;
+
+		RevisionLimitMetaBox::save( 42, $post );
+
+		self::assertSame( -1, $this->updated_meta[0]['value'] );
+	}
+}

--- a/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
+++ b/tests/Unit/Admin/RevisionLimitMetaBoxTest.php
@@ -68,10 +68,11 @@ final class RevisionLimitMetaBoxTest extends TestCase {
 	}
 
 	/**
-	 * Tears down Brain Monkey.
+	 * Tears down Brain Monkey and clears $_POST so state cannot leak.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
+		$_POST = [];
 		parent::tearDown();
 	}
 

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Admin;
+
+use Apermo\AdvancedRevisions\Admin\SettingsPage;
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Tests for SettingsPage — focus on the sanitizer (pure logic) and hook wiring.
+ * Rendering tests live at the integration / E2E layer.
+ */
+final class SettingsPageTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Stub get_post_types to return a fixed set of revisable types.
+	 *
+	 * @param array<int, string> $types Post type slugs to consider revisable.
+	 */
+	private function stub_post_types( array $types ): void {
+		$post_type_objects = [];
+		foreach ( $types as $type ) {
+			// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass -- minimal WP_Post_Type stand-in for unit test.
+			$post_type_object = new stdClass();
+			$post_type_object->name = $type;
+			// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+			$post_type_object->labels = new stdClass();
+			$post_type_object->labels->name = \ucfirst( $type );
+
+			$post_type_objects[ $type ] = $post_type_object;
+		}
+
+		Functions\when( 'get_post_types' )->justReturn( $post_type_objects );
+		Functions\when( 'post_type_supports' )->justReturn( true );
+	}
+
+	/**
+	 * Registering hooks admin_menu and admin_init.
+	 */
+	public function test_register_hooks_admin_menu_and_admin_init(): void {
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'admin_menu', [ SettingsPage::class, 'add_page' ] );
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'admin_init', [ SettingsPage::class, 'register_settings' ] );
+
+		SettingsPage::register();
+	}
+
+	/**
+	 * Sanitizer drops keys for post types that don't support revisions.
+	 */
+	public function test_sanitize_drops_unknown_post_types(): void {
+		$this->stub_post_types( [ 'post', 'page' ] );
+
+		$cleaned = SettingsPage::sanitize_settings(
+			[
+				LimitService::LIMITS_KEY => [
+					'post'        => 10,
+					'not_a_type'  => 5,
+				],
+			],
+		);
+
+		self::assertSame(
+			[ LimitService::LIMITS_KEY => [ 'post' => 10 ] ],
+			$cleaned,
+		);
+	}
+
+	/**
+	 * Sanitizer coerces string numbers and clamps below -1.
+	 */
+	public function test_sanitize_clamps_and_coerces(): void {
+		$this->stub_post_types( [ 'post' ] );
+
+		$cleaned = SettingsPage::sanitize_settings(
+			[ LimitService::LIMITS_KEY => [ 'post' => '-99' ] ],
+		);
+
+		self::assertSame(
+			[ LimitService::LIMITS_KEY => [ 'post' => -1 ] ],
+			$cleaned,
+		);
+	}
+
+	/**
+	 * Empty string values are treated as "inherit" and dropped from storage.
+	 */
+	public function test_sanitize_drops_empty_strings(): void {
+		$this->stub_post_types( [ 'post', 'page' ] );
+
+		$cleaned = SettingsPage::sanitize_settings(
+			[
+				LimitService::LIMITS_KEY => [
+					'post' => '',
+					'page' => 7,
+				],
+			],
+		);
+
+		self::assertSame(
+			[ LimitService::LIMITS_KEY => [ 'page' => 7 ] ],
+			$cleaned,
+		);
+	}
+
+	/**
+	 * Non-array inputs normalize to an empty limits map (never crash).
+	 */
+	public function test_sanitize_handles_non_array_input(): void {
+		$cleaned = SettingsPage::sanitize_settings( 'garbage' );
+
+		self::assertSame( [ LimitService::LIMITS_KEY => [] ], $cleaned );
+	}
+}

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -56,7 +56,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Registering hooks admin_menu and admin_init.
+	 * Verifies register() wires admin_menu and admin_init hooks.
 	 */
 	public function test_register_hooks_admin_menu_and_admin_init(): void {
 		Functions\expect( 'add_action' )
@@ -70,7 +70,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Sanitizer drops keys for post types that don't support revisions.
+	 * Asserts the sanitizer drops keys for post types that don't support revisions.
 	 */
 	public function test_sanitize_drops_unknown_post_types(): void {
 		$this->stub_post_types( [ 'post', 'page' ] );
@@ -91,7 +91,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Sanitizer coerces string numbers and clamps below -1.
+	 * Asserts the sanitizer coerces string numbers and clamps below -1.
 	 */
 	public function test_sanitize_clamps_and_coerces(): void {
 		$this->stub_post_types( [ 'post' ] );
@@ -107,7 +107,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Empty string values are treated as "inherit" and dropped from storage.
+	 * Verifies that empty string values are treated as "inherit" and dropped from storage.
 	 */
 	public function test_sanitize_drops_empty_strings(): void {
 		$this->stub_post_types( [ 'post', 'page' ] );
@@ -128,7 +128,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * The add_page helper registers under Settings with the expected slug + capability.
+	 * Verifies the add_page helper registers under Settings with the expected slug + capability.
 	 */
 	public function test_add_page_registers_under_settings(): void {
 		Functions\when( '__' )->returnArg();
@@ -142,7 +142,7 @@ final class SettingsPageTest extends TestCase {
 
 		SettingsPage::add_page();
 
-		self::assertSame( SettingsPage::CAPABILITY, $captured[2] );
+		self::assertSame( SettingsPage::REQUIRED_CAPABILITY, $captured[2] );
 		self::assertSame( SettingsPage::MENU_SLUG, $captured[3] );
 	}
 
@@ -180,7 +180,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Section-intro rendering prints a description paragraph.
+	 * Verifies section-intro rendering prints a description paragraph.
 	 */
 	public function test_render_section_intro_prints_description(): void {
 		Functions\when( 'esc_html__' )->returnArg();
@@ -194,7 +194,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Limit-field rendering prints a number input for the given post type.
+	 * Verifies limit-field rendering prints a number input for the given post type.
 	 */
 	public function test_render_limit_field_prints_input(): void {
 		Functions\when( 'get_post_meta' )->justReturn( '' );
@@ -209,7 +209,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Page rendering bails when user lacks capability.
+	 * Asserts page rendering bails when user lacks capability.
 	 */
 	public function test_render_page_bails_without_capability(): void {
 		Functions\when( 'current_user_can' )->justReturn( false );
@@ -222,7 +222,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Page rendering emits the standard wrap + form when capable.
+	 * Verifies page rendering emits the standard wrap + form when capable.
 	 */
 	public function test_render_page_emits_wrap_and_form(): void {
 		Functions\when( 'current_user_can' )->justReturn( true );
@@ -240,7 +240,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Non-array inputs normalize to an empty limits map (never crash).
+	 * Verifies non-array inputs normalize to an empty limits map (never crash).
 	 */
 	public function test_sanitize_handles_non_array_input(): void {
 		$cleaned = SettingsPage::sanitize_settings( 'garbage' );

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -18,7 +18,7 @@ use stdClass;
 final class SettingsPageTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -26,7 +26,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
@@ -34,7 +34,7 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
-	 * Stub get_post_types to return a fixed set of revisable types.
+	 * Stubs get_post_types to return a fixed set of revisable types.
 	 *
 	 * @param array<int, string> $types Post type slugs to consider revisable.
 	 */

--- a/tests/Unit/Admin/SettingsPageTest.php
+++ b/tests/Unit/Admin/SettingsPageTest.php
@@ -128,6 +128,118 @@ final class SettingsPageTest extends TestCase {
 	}
 
 	/**
+	 * The add_page helper registers under Settings with the expected slug + capability.
+	 */
+	public function test_add_page_registers_under_settings(): void {
+		Functions\when( '__' )->returnArg();
+		$captured = [];
+		Functions\when( 'add_options_page' )->alias(
+			static function ( string $title, string $menu, string $cap, string $slug, $cb ) use ( &$captured ): void {
+				unset( $cb );
+				$captured = [ $title, $menu, $cap, $slug ];
+			},
+		);
+
+		SettingsPage::add_page();
+
+		self::assertSame( SettingsPage::CAPABILITY, $captured[2] );
+		self::assertSame( SettingsPage::MENU_SLUG, $captured[3] );
+	}
+
+	/**
+	 * Settings API is wired via register_settings.
+	 */
+	public function test_register_settings_wires_settings_api(): void {
+		$this->stub_post_types( [ 'post', 'page' ] );
+		Functions\when( '__' )->returnArg();
+
+		$register = 0;
+		$section  = 0;
+		$field    = 0;
+		Functions\when( 'register_setting' )->alias(
+			static function () use ( &$register ): void {
+				$register++;
+			},
+		);
+		Functions\when( 'add_settings_section' )->alias(
+			static function () use ( &$section ): void {
+				$section++;
+			},
+		);
+		Functions\when( 'add_settings_field' )->alias(
+			static function () use ( &$field ): void {
+				$field++;
+			},
+		);
+
+		SettingsPage::register_settings();
+
+		self::assertSame( 1, $register );
+		self::assertSame( 1, $section );
+		self::assertSame( 2, $field );
+	}
+
+	/**
+	 * Section-intro rendering prints a description paragraph.
+	 */
+	public function test_render_section_intro_prints_description(): void {
+		Functions\when( 'esc_html__' )->returnArg();
+
+		\ob_start();
+		SettingsPage::render_section_intro();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( '<p>', $output );
+		self::assertStringContainsString( 'revisions', \strtolower( $output ) );
+	}
+
+	/**
+	 * Limit-field rendering prints a number input for the given post type.
+	 */
+	public function test_render_limit_field_prints_input(): void {
+		Functions\when( 'get_post_meta' )->justReturn( '' );
+		Functions\when( 'get_option' )->justReturn( [] );
+		Functions\when( 'esc_attr' )->returnArg();
+
+		\ob_start();
+		SettingsPage::render_limit_field( [ 'post_type' => 'post' ] );
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( '<input type="number"', $output );
+	}
+
+	/**
+	 * Page rendering bails when user lacks capability.
+	 */
+	public function test_render_page_bails_without_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		\ob_start();
+		SettingsPage::render_page();
+		$output = (string) \ob_get_clean();
+
+		self::assertSame( '', $output );
+	}
+
+	/**
+	 * Page rendering emits the standard wrap + form when capable.
+	 */
+	public function test_render_page_emits_wrap_and_form(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( 'settings_fields' )->justReturn( '' );
+		Functions\when( 'do_settings_sections' )->justReturn( '' );
+		Functions\when( 'submit_button' )->justReturn( '' );
+
+		\ob_start();
+		SettingsPage::render_page();
+		$output = (string) \ob_get_clean();
+
+		self::assertStringContainsString( '<div class="wrap">', $output );
+		self::assertStringContainsString( '<form', $output );
+	}
+
+	/**
 	 * Non-array inputs normalize to an empty limits map (never crash).
 	 */
 	public function test_sanitize_handles_non_array_input(): void {

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -36,7 +36,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify init registers activation and deactivation hooks.
+	 * Verifies init() registers activation and deactivation hooks.
 	 *
 	 * @return void
 	 */
@@ -59,7 +59,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify init stores the plugin file path.
+	 * Verifies init() stores the plugin file path.
 	 *
 	 * @return void
 	 */
@@ -80,7 +80,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify activate can be called without error.
+	 * Verifies activate() can be called without error.
 	 *
 	 * @return void
 	 */
@@ -90,7 +90,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify deactivate can be called without error.
+	 * Verifies deactivate() can be called without error.
 	 *
 	 * @return void
 	 */
@@ -100,7 +100,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify boot wires the per-type revision limit filter.
+	 * Verifies boot() wires the per-type revision limit filter.
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class PluginTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 *
 	 * @return void
 	 */
@@ -26,7 +26,7 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -7,6 +7,7 @@ namespace Apermo\AdvancedRevisions\Tests\Unit;
 use Apermo\AdvancedRevisions\Plugin;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -99,12 +100,16 @@ class PluginTest extends TestCase {
 	}
 
 	/**
-	 * Verify boot can be called without error.
+	 * Verify boot wires the per-type revision limit filter.
 	 *
 	 * @return void
 	 */
 	public function test_boot(): void {
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\expect( 'add_filter' )
+			->once()
+			->with( 'wp_revisions_to_keep', Mockery::type( 'array' ), 10, 2 );
+
 		Plugin::boot();
-		$this->assertTrue( true );
 	}
 }

--- a/tests/Unit/Revisions/LimitServiceTest.php
+++ b/tests/Unit/Revisions/LimitServiceTest.php
@@ -16,7 +16,7 @@ use WP_Post;
 final class LimitServiceTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -27,7 +27,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
@@ -35,7 +35,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Build a WP_Post stub with the given post_type.
+	 * Builds a WP_Post stub with the given post_type.
 	 *
 	 * @param string $post_type Post type slug.
 	 */

--- a/tests/Unit/Revisions/LimitServiceTest.php
+++ b/tests/Unit/Revisions/LimitServiceTest.php
@@ -46,7 +46,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * With no stored limits, filter returns the original count unchanged.
+	 * Asserts that with no stored limits, the filter returns the original count unchanged.
 	 */
 	public function test_filter_returns_original_when_no_limits_configured(): void {
 		Functions\when( 'get_option' )->justReturn( [] );
@@ -57,7 +57,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * A configured limit for the post's type overrides the original count.
+	 * Verifies a configured limit for the post's type overrides the original count.
 	 */
 	public function test_filter_overrides_with_configured_limit(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -70,7 +70,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * A configured limit for a different type does not affect this post.
+	 * Asserts a configured limit for a different type does not affect this post.
 	 */
 	public function test_filter_leaves_non_matching_types_alone(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -83,7 +83,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * A limit of 0 disables revisions for the post type.
+	 * Verifies a limit of 0 disables revisions for the post type.
 	 */
 	public function test_filter_applies_zero_to_disable_revisions(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -96,7 +96,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * A limit of -1 signals unlimited, matching core's WP_POST_REVISIONS convention.
+	 * Verifies a limit of -1 signals unlimited, matching core's WP_POST_REVISIONS convention.
 	 */
 	public function test_filter_applies_minus_one_for_unlimited(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -109,7 +109,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Malformed option data (non-array) is ignored.
+	 * Ignores malformed option data (non-array).
 	 */
 	public function test_filter_ignores_malformed_option_data(): void {
 		Functions\when( 'get_option' )->justReturn( 'not-an-array' );
@@ -120,7 +120,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Non-string post_type keys in stored limits are stripped by sanitization.
+	 * Strips non-string post_type keys from stored limits during sanitization.
 	 */
 	public function test_stored_limits_drops_non_string_keys(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -139,7 +139,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * The limit_for_type helper returns null when no override is stored.
+	 * Returns null from limit_for_type() when no override is stored.
 	 */
 	public function test_limit_for_type_returns_null_when_unset(): void {
 		Functions\when( 'get_option' )->justReturn( [ LimitService::LIMITS_KEY => [] ] );
@@ -148,7 +148,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Per-post override wins over the per-type rule.
+	 * Asserts per-post override wins over the per-type rule.
 	 */
 	public function test_per_post_override_beats_per_type_limit(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -166,7 +166,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * An empty per-post meta value means "inherit" — per-type limit wins.
+	 * Treats an empty per-post meta value as "inherit" — per-type limit wins.
 	 */
 	public function test_empty_per_post_meta_inherits_per_type_limit(): void {
 		Functions\when( 'get_option' )->justReturn(
@@ -184,7 +184,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Per-post override clamps to -1 at minimum.
+	 * Clamps per-post override to -1 at minimum.
 	 */
 	public function test_per_post_override_clamps_below_minus_one(): void {
 		Functions\when( 'get_post_meta' )->justReturn( '-99' );
@@ -193,7 +193,7 @@ final class LimitServiceTest extends TestCase {
 	}
 
 	/**
-	 * Registering hooks the filter on wp_revisions_to_keep.
+	 * Verifies register() hooks the filter on wp_revisions_to_keep.
 	 */
 	public function test_register_hooks_the_filter(): void {
 		Functions\expect( 'add_filter' )

--- a/tests/Unit/Revisions/LimitServiceTest.php
+++ b/tests/Unit/Revisions/LimitServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Revisions;
+
+use Apermo\AdvancedRevisions\Revisions\LimitService;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Tests for LimitService's wp_revisions_to_keep filter behavior.
+ */
+final class LimitServiceTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a WP_Post stub with the given post_type.
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	private function post_of( string $post_type ): WP_Post {
+		$post            = new WP_Post();
+		$post->post_type = $post_type;
+		return $post;
+	}
+
+	/**
+	 * With no stored limits, filter returns the original count unchanged.
+	 */
+	public function test_filter_returns_original_when_no_limits_configured(): void {
+		Functions\when( 'get_option' )->justReturn( [] );
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( 5, $result );
+	}
+
+	/**
+	 * A configured limit for the post's type overrides the original count.
+	 */
+	public function test_filter_overrides_with_configured_limit(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'post' => 12 ] ],
+		);
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( 12, $result );
+	}
+
+	/**
+	 * A configured limit for a different type does not affect this post.
+	 */
+	public function test_filter_leaves_non_matching_types_alone(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'page' => 2 ] ],
+		);
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( 5, $result );
+	}
+
+	/**
+	 * A limit of 0 disables revisions for the post type.
+	 */
+	public function test_filter_applies_zero_to_disable_revisions(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'post' => 0 ] ],
+		);
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( 0, $result );
+	}
+
+	/**
+	 * A limit of -1 signals unlimited, matching core's WP_POST_REVISIONS convention.
+	 */
+	public function test_filter_applies_minus_one_for_unlimited(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'post' => -1 ] ],
+		);
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( -1, $result );
+	}
+
+	/**
+	 * Malformed option data (non-array) is ignored.
+	 */
+	public function test_filter_ignores_malformed_option_data(): void {
+		Functions\when( 'get_option' )->justReturn( 'not-an-array' );
+
+		$result = LimitService::filter_revisions_to_keep( 5, $this->post_of( 'post' ) );
+
+		self::assertSame( 5, $result );
+	}
+
+	/**
+	 * Non-string post_type keys in stored limits are stripped by sanitization.
+	 */
+	public function test_stored_limits_drops_non_string_keys(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[
+				LimitService::LIMITS_KEY => [
+					'post' => 10,
+					0      => 20,
+				],
+			],
+		);
+
+		$limits = LimitService::stored_limits();
+
+		self::assertArrayHasKey( 'post', $limits );
+		self::assertArrayNotHasKey( 0, $limits );
+	}
+
+	/**
+	 * The limit_for_type helper returns null when no override is stored.
+	 */
+	public function test_limit_for_type_returns_null_when_unset(): void {
+		Functions\when( 'get_option' )->justReturn( [ LimitService::LIMITS_KEY => [] ] );
+
+		self::assertNull( LimitService::limit_for_type( 'post' ) );
+	}
+
+	/**
+	 * Registering hooks the filter on wp_revisions_to_keep.
+	 */
+	public function test_register_hooks_the_filter(): void {
+		Functions\expect( 'add_filter' )
+			->once()
+			->with( 'wp_revisions_to_keep', [ LimitService::class, 'filter_revisions_to_keep' ], 10, 2 );
+
+		LimitService::register();
+	}
+}

--- a/tests/Unit/Revisions/LimitServiceTest.php
+++ b/tests/Unit/Revisions/LimitServiceTest.php
@@ -21,6 +21,9 @@ final class LimitServiceTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+
+		// Default: no per-post override. Tests that need one override this stub.
+		Functions\when( 'get_post_meta' )->justReturn( '' );
 	}
 
 	/**
@@ -142,6 +145,51 @@ final class LimitServiceTest extends TestCase {
 		Functions\when( 'get_option' )->justReturn( [ LimitService::LIMITS_KEY => [] ] );
 
 		self::assertNull( LimitService::limit_for_type( 'post' ) );
+	}
+
+	/**
+	 * Per-post override wins over the per-type rule.
+	 */
+	public function test_per_post_override_beats_per_type_limit(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'post' => 5 ] ],
+		);
+		Functions\when( 'get_post_meta' )->justReturn( 99 );
+
+		$post            = new WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$result = LimitService::filter_revisions_to_keep( 3, $post );
+
+		self::assertSame( 99, $result );
+	}
+
+	/**
+	 * An empty per-post meta value means "inherit" — per-type limit wins.
+	 */
+	public function test_empty_per_post_meta_inherits_per_type_limit(): void {
+		Functions\when( 'get_option' )->justReturn(
+			[ LimitService::LIMITS_KEY => [ 'post' => 5 ] ],
+		);
+		Functions\when( 'get_post_meta' )->justReturn( '' );
+
+		$post            = new WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$result = LimitService::filter_revisions_to_keep( 3, $post );
+
+		self::assertSame( 5, $result );
+	}
+
+	/**
+	 * Per-post override clamps to -1 at minimum.
+	 */
+	public function test_per_post_override_clamps_below_minus_one(): void {
+		Functions\when( 'get_post_meta' )->justReturn( '-99' );
+
+		self::assertSame( -1, LimitService::per_post_override( 42 ) );
 	}
 
 	/**

--- a/tests/Unit/Revisions/ProtectionServiceTest.php
+++ b/tests/Unit/Revisions/ProtectionServiceTest.php
@@ -17,7 +17,7 @@ use stdClass;
 final class ProtectionServiceTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -25,7 +25,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
@@ -33,7 +33,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Stub revision→term and term→protected maps.
+	 * Stubs revision→term and term→protected maps.
 	 *
 	 * @param array<int, array<int, int>> $terms_by_revision   revision_id → list of term IDs.
 	 * @param array<int, bool>            $protected_by_term   term_id → protected flag.

--- a/tests/Unit/Revisions/ProtectionServiceTest.php
+++ b/tests/Unit/Revisions/ProtectionServiceTest.php
@@ -65,7 +65,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Empty input returns empty array without hitting the DB.
+	 * Asserts empty input returns an empty array without hitting the DB.
 	 */
 	public function test_filter_deletable_returns_empty_for_empty_input(): void {
 		self::assertSame( [], ProtectionService::filter_deletable( [] ) );
@@ -125,7 +125,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * A revision with a mix of protected and unprotected tags stays protected.
+	 * Asserts a revision with a mix of protected and unprotected tags stays protected.
 	 */
 	public function test_filter_deletable_respects_any_protected_tag(): void {
 		$this->stub_tags(
@@ -142,7 +142,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Count helper reports how many IDs are protected (useful for UI).
+	 * Asserts the count helper reports how many IDs are protected (useful for UI).
 	 */
 	public function test_count_protected_reports_how_many_ids_are_protected(): void {
 		$this->stub_tags(
@@ -162,7 +162,7 @@ final class ProtectionServiceTest extends TestCase {
 	}
 
 	/**
-	 * Count helper uses the same taxonomy constant as the service itself.
+	 * Asserts the count helper uses the same taxonomy constant as the service itself.
 	 */
 	public function test_taxonomy_constant_matches_registrar(): void {
 		self::assertSame( TaxonomyRegistrar::TAXONOMY, 'revision_tag' );

--- a/tests/Unit/Revisions/ProtectionServiceTest.php
+++ b/tests/Unit/Revisions/ProtectionServiceTest.php
@@ -9,6 +9,7 @@ use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * Tests for ProtectionService::filter_deletable().
@@ -39,9 +40,20 @@ final class ProtectionServiceTest extends TestCase {
 	 */
 	private function stub_tags( array $terms_by_revision, array $protected_by_term ): void {
 		Functions\when( 'wp_get_object_terms' )->alias(
-			static function ( int $revision_id, string $taxonomy, array $args ) use ( $terms_by_revision ): array {
+			// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
+			static function ( array $object_ids, string $taxonomy, array $args ) use ( $terms_by_revision ): array {
 				unset( $taxonomy, $args );
-				return $terms_by_revision[ $revision_id ] ?? [];
+				$rows = [];
+				foreach ( $object_ids as $object_id ) {
+					foreach ( $terms_by_revision[ $object_id ] ?? [] as $term_id ) {
+						// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+						$row_data            = new stdClass();
+						$row_data->object_id = $object_id;
+						$row_data->term_id   = $term_id;
+						$rows[]              = $row_data;
+					}
+				}
+				return $rows;
 			},
 		);
 		Functions\when( 'get_term_meta' )->alias(

--- a/tests/Unit/Revisions/ProtectionServiceTest.php
+++ b/tests/Unit/Revisions/ProtectionServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Revisions;
+
+use Apermo\AdvancedRevisions\Revisions\ProtectionService;
+use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ProtectionService::filter_deletable().
+ */
+final class ProtectionServiceTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Stub revision→term and term→protected maps.
+	 *
+	 * @param array<int, array<int, int>> $terms_by_revision   revision_id → list of term IDs.
+	 * @param array<int, bool>            $protected_by_term   term_id → protected flag.
+	 */
+	private function stub_tags( array $terms_by_revision, array $protected_by_term ): void {
+		Functions\when( 'wp_get_object_terms' )->alias(
+			static function ( int $revision_id, string $taxonomy, array $args ) use ( $terms_by_revision ): array {
+				unset( $taxonomy, $args );
+				return $terms_by_revision[ $revision_id ] ?? [];
+			},
+		);
+		Functions\when( 'get_term_meta' )->alias(
+			static function ( int $term_id, string $key, bool $single ) use ( $protected_by_term ): bool {
+				unset( $key, $single );
+				return $protected_by_term[ $term_id ] ?? false;
+			},
+		);
+	}
+
+	/**
+	 * Empty input returns empty array without hitting the DB.
+	 */
+	public function test_filter_deletable_returns_empty_for_empty_input(): void {
+		self::assertSame( [], ProtectionService::filter_deletable( [] ) );
+	}
+
+	/**
+	 * Revisions without any tags are always deletable.
+	 */
+	public function test_filter_deletable_keeps_untagged_revisions(): void {
+		$this->stub_tags( [], [] );
+
+		$result = ProtectionService::filter_deletable( [ 1, 2, 3 ] );
+
+		self::assertSame( [ 1, 2, 3 ], $result );
+	}
+
+	/**
+	 * Revisions tagged only with non-protected tags are deletable.
+	 */
+	public function test_filter_deletable_keeps_non_protected_tagged_revisions(): void {
+		$this->stub_tags(
+			[
+				10 => [ 100, 101 ],
+				11 => [ 101 ],
+			],
+			[
+				100 => false,
+				101 => false,
+			],
+		);
+
+		$result = ProtectionService::filter_deletable( [ 10, 11 ] );
+
+		self::assertSame( [ 10, 11 ], $result );
+	}
+
+	/**
+	 * Revisions wearing at least one protected tag are removed.
+	 */
+	public function test_filter_deletable_drops_protected_revisions(): void {
+		$this->stub_tags(
+			[
+				10 => [ 100 ],
+				11 => [ 101 ],
+				12 => [ 100, 102 ],
+			],
+			[
+				100 => false,
+				101 => true,
+				102 => false,
+			],
+		);
+
+		$result = ProtectionService::filter_deletable( [ 10, 11, 12 ] );
+
+		self::assertSame( [ 10, 12 ], $result );
+	}
+
+	/**
+	 * A revision with a mix of protected and unprotected tags stays protected.
+	 */
+	public function test_filter_deletable_respects_any_protected_tag(): void {
+		$this->stub_tags(
+			[ 10 => [ 100, 101 ] ],
+			[
+				100 => false,
+				101 => true,
+			],
+		);
+
+		$result = ProtectionService::filter_deletable( [ 10 ] );
+
+		self::assertSame( [], $result );
+	}
+
+	/**
+	 * Count helper reports how many IDs are protected (useful for UI).
+	 */
+	public function test_count_protected_reports_how_many_ids_are_protected(): void {
+		$this->stub_tags(
+			[
+				10 => [ 100 ],
+				11 => [ 101 ],
+				12 => [ 102 ],
+			],
+			[
+				100 => true,
+				101 => false,
+				102 => true,
+			],
+		);
+
+		self::assertSame( 2, ProtectionService::count_protected( [ 10, 11, 12 ] ) );
+	}
+
+	/**
+	 * Count helper uses the same taxonomy constant as the service itself.
+	 */
+	public function test_taxonomy_constant_matches_registrar(): void {
+		self::assertSame( TaxonomyRegistrar::TAXONOMY, 'revision_tag' );
+	}
+}

--- a/tests/Unit/Revisions/ProtectionServiceTest.php
+++ b/tests/Unit/Revisions/ProtectionServiceTest.php
@@ -22,6 +22,7 @@ final class ProtectionServiceTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		Functions\when( 'update_termmeta_cache' )->justReturn( [] );
 	}
 
 	/**

--- a/tests/Unit/Revisions/RevisionDeleterTest.php
+++ b/tests/Unit/Revisions/RevisionDeleterTest.php
@@ -18,7 +18,7 @@ use stdClass;
 final class RevisionDeleterTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -26,7 +26,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
@@ -34,7 +34,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * Build a repository stub that returns a fixed set of revision IDs per parent.
+	 * Builds a repository stub that returns a fixed set of revision IDs per parent.
 	 *
 	 * @param array<int, int> $revision_ids Revision IDs to return.
 	 */

--- a/tests/Unit/Revisions/RevisionDeleterTest.php
+++ b/tests/Unit/Revisions/RevisionDeleterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Revisions;
+
+use Apermo\AdvancedRevisions\Revisions\RevisionDeleter;
+use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for RevisionDeleter — verifies protection is honored and deletion
+ * counts are reported accurately.
+ */
+final class RevisionDeleterTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a repository stub that returns a fixed set of revision IDs per parent.
+	 *
+	 * @param array<int, int> $revision_ids Revision IDs to return.
+	 */
+	private function stub_repository( array $revision_ids ): RevisionRepository {
+		$stub = $this->createMock( RevisionRepository::class );
+		$stub->method( 'revision_ids_for_parents' )->willReturn( $revision_ids );
+		return $stub;
+	}
+
+	/**
+	 * Deletion walks each revision ID and increments the count for successes.
+	 */
+	public function test_delete_counts_successful_deletions(): void {
+		// No tags → nothing protected.
+		Functions\when( 'wp_get_object_terms' )->justReturn( [] );
+		Functions\when( 'wp_delete_post_revision' )->justReturn( 1 );
+
+		$deleter = new RevisionDeleter( $this->stub_repository( [ 10, 11, 12 ] ) );
+
+		$result = $deleter->delete_for_parents( [ 100 ] );
+
+		self::assertSame(
+			[
+				'deleted' => 3,
+				'skipped' => 0,
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * A revision returning false from wp_delete_post_revision is not counted as deleted.
+	 */
+	public function test_delete_skips_rows_that_fail_to_delete(): void {
+		Functions\when( 'wp_get_object_terms' )->justReturn( [] );
+		Functions\when( 'wp_delete_post_revision' )->alias(
+			static fn( int $id ): mixed => $id === 11 ? false : 1,
+		);
+
+		$deleter = new RevisionDeleter( $this->stub_repository( [ 10, 11, 12 ] ) );
+
+		$result = $deleter->delete_for_parents( [ 100 ] );
+
+		self::assertSame( 2, $result['deleted'] );
+	}
+
+	/**
+	 * Protected revisions are skipped and reported.
+	 */
+	public function test_delete_respects_protection_flags(): void {
+		Functions\when( 'wp_get_object_terms' )->alias(
+			static fn( int $id ): array => $id === 11 ? [ 500 ] : [],
+		);
+		Functions\when( 'get_term_meta' )->justReturn( true );
+		Functions\when( 'wp_delete_post_revision' )->justReturn( 1 );
+
+		$deleter = new RevisionDeleter( $this->stub_repository( [ 10, 11, 12 ] ) );
+
+		$result = $deleter->delete_for_parents( [ 100 ] );
+
+		self::assertSame(
+			[
+				'deleted' => 2,
+				'skipped' => 1,
+			],
+			$result,
+		);
+	}
+
+	/**
+	 * Preview reports deletable + protected counts without calling wp_delete_post_revision.
+	 */
+	public function test_preview_reports_counts_without_deleting(): void {
+		Functions\when( 'wp_get_object_terms' )->alias(
+			static fn( int $id ): array => $id === 10 ? [ 500 ] : [],
+		);
+		Functions\when( 'get_term_meta' )->justReturn( true );
+		Functions\expect( 'wp_delete_post_revision' )->never();
+
+		$deleter = new RevisionDeleter( $this->stub_repository( [ 10, 11, 12 ] ) );
+
+		$result = $deleter->preview( [ 100 ] );
+
+		self::assertSame(
+			[
+				'deletable' => 2,
+				'protected' => 1,
+			],
+			$result,
+		);
+	}
+}

--- a/tests/Unit/Revisions/RevisionDeleterTest.php
+++ b/tests/Unit/Revisions/RevisionDeleterTest.php
@@ -45,7 +45,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * Deletion walks each revision ID and increments the count for successes.
+	 * Walks each revision ID during deletion and increments the count for successes.
 	 */
 	public function test_delete_counts_successful_deletions(): void {
 		// No tags → nothing protected.
@@ -66,7 +66,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * A revision returning false from wp_delete_post_revision is not counted as deleted.
+	 * Skips revisions that return false from wp_delete_post_revision.
 	 */
 	public function test_delete_skips_rows_that_fail_to_delete(): void {
 		Functions\when( 'wp_get_object_terms' )->justReturn( [] );
@@ -82,7 +82,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * Protected revisions are skipped and reported.
+	 * Skips protected revisions and reports them.
 	 */
 	public function test_delete_respects_protection_flags(): void {
 		Functions\when( 'wp_get_object_terms' )->alias(
@@ -116,7 +116,7 @@ final class RevisionDeleterTest extends TestCase {
 	}
 
 	/**
-	 * Preview reports deletable + protected counts without calling wp_delete_post_revision.
+	 * Reports deletable + protected counts via preview without calling wp_delete_post_revision.
 	 */
 	public function test_preview_reports_counts_without_deleting(): void {
 		Functions\when( 'wp_get_object_terms' )->alias(

--- a/tests/Unit/Revisions/RevisionDeleterTest.php
+++ b/tests/Unit/Revisions/RevisionDeleterTest.php
@@ -23,6 +23,7 @@ final class RevisionDeleterTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		Functions\when( 'update_termmeta_cache' )->justReturn( [] );
 	}
 
 	/**

--- a/tests/Unit/Revisions/RevisionDeleterTest.php
+++ b/tests/Unit/Revisions/RevisionDeleterTest.php
@@ -9,6 +9,7 @@ use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * Tests for RevisionDeleter — verifies protection is honored and deletion
@@ -85,7 +86,18 @@ final class RevisionDeleterTest extends TestCase {
 	 */
 	public function test_delete_respects_protection_flags(): void {
 		Functions\when( 'wp_get_object_terms' )->alias(
-			static fn( int $id ): array => $id === 11 ? [ 500 ] : [],
+			// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
+			static function ( array $ids ): array {
+				$rows = [];
+				if ( \in_array( 11, $ids, true ) ) {
+					// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+					$row_data            = new stdClass();
+					$row_data->object_id = 11;
+					$row_data->term_id   = 500;
+					$rows[]              = $row_data;
+				}
+				return $rows;
+			},
 		);
 		Functions\when( 'get_term_meta' )->justReturn( true );
 		Functions\when( 'wp_delete_post_revision' )->justReturn( 1 );
@@ -108,7 +120,18 @@ final class RevisionDeleterTest extends TestCase {
 	 */
 	public function test_preview_reports_counts_without_deleting(): void {
 		Functions\when( 'wp_get_object_terms' )->alias(
-			static fn( int $id ): array => $id === 10 ? [ 500 ] : [],
+			// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
+			static function ( array $ids ): array {
+				$rows = [];
+				if ( \in_array( 10, $ids, true ) ) {
+					// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+					$row_data            = new stdClass();
+					$row_data->object_id = 10;
+					$row_data->term_id   = 500;
+					$rows[]              = $row_data;
+				}
+				return $rows;
+			},
 		);
 		Functions\when( 'get_term_meta' )->justReturn( true );
 		Functions\expect( 'wp_delete_post_revision' )->never();

--- a/tests/Unit/Revisions/RevisionRepositoryTest.php
+++ b/tests/Unit/Revisions/RevisionRepositoryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Revisions;
+
+use Apermo\AdvancedRevisions\Revisions\RevisionRepository;
+use Apermo\AdvancedRevisions\Tests\Fixtures\WpdbDouble;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Unit tests for RevisionRepository. We stub a tiny $wpdb double so the
+ * SQL-execution paths are covered without a real DB.
+ */
+final class RevisionRepositoryTest extends TestCase {
+
+	/**
+	 * Install a tiny $wpdb double.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- test-local wpdb stub.
+		$GLOBALS['wpdb'] = new WpdbDouble();
+	}
+
+	/**
+	 * Remove the $wpdb double.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * The paginated helper returns an empty array when $wpdb is not initialized.
+	 */
+	public function test_paginated_returns_empty_without_wpdb(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		self::assertSame( [], ( new RevisionRepository() )->paginated() );
+	}
+
+	/**
+	 * The paginated helper maps $wpdb->get_results output into the overview row shape.
+	 */
+	public function test_paginated_maps_db_rows_to_overview_shape(): void {
+		// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
+		$row_data                 = new stdClass();
+		$row_data->ID             = 42;
+		$row_data->post_title     = 'Hello';
+		$row_data->post_type      = 'post';
+		$row_data->post_author    = 3;
+		$row_data->revision_count = 12;
+		$row_data->oldest_gmt     = '2024-01-01 00:00:00';
+
+		$GLOBALS['wpdb']->next_results = [ $row_data ];
+
+		$rows = ( new RevisionRepository() )->paginated();
+
+		self::assertCount( 1, $rows );
+		self::assertSame( 42, $rows[0]['id'] );
+		self::assertSame( 'Hello', $rows[0]['title'] );
+		self::assertSame( 'post', $rows[0]['post_type'] );
+		self::assertSame( 3, $rows[0]['author'] );
+		self::assertSame( 12, $rows[0]['revisions'] );
+		self::assertSame( '2024-01-01 00:00:00', $rows[0]['oldest_gmt'] );
+	}
+
+	/**
+	 * The paginated helper clamps per_page into a safe range.
+	 */
+	public function test_paginated_clamps_per_page(): void {
+		$GLOBALS['wpdb']->next_results = [];
+
+		self::assertSame( [], ( new RevisionRepository() )->paginated( 0, 1 ) );
+		self::assertSame( [], ( new RevisionRepository() )->paginated( 99_999, 1 ) );
+	}
+
+	/**
+	 * The total_parents helper returns 0 when $wpdb is not available.
+	 */
+	public function test_total_parents_returns_zero_without_wpdb(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		self::assertSame( 0, ( new RevisionRepository() )->total_parents() );
+	}
+
+	/**
+	 * The total_parents helper returns the DB count as int.
+	 */
+	public function test_total_parents_returns_db_count(): void {
+		$GLOBALS['wpdb']->next_var = 17;
+
+		self::assertSame( 17, ( new RevisionRepository() )->total_parents() );
+	}
+
+	/**
+	 * The revision_ids_for_parents helper short-circuits on empty input.
+	 */
+	public function test_revision_ids_for_parents_returns_empty_for_empty_input(): void {
+		self::assertSame( [], ( new RevisionRepository() )->revision_ids_for_parents( [] ) );
+	}
+
+	/**
+	 * The revision_ids_for_parents helper returns an int list from $wpdb->get_col.
+	 */
+	public function test_revision_ids_for_parents_casts_db_values_to_int(): void {
+		$GLOBALS['wpdb']->next_col = [ '101', '102', 103 ];
+
+		$ids = ( new RevisionRepository() )->revision_ids_for_parents( [ 10, 11 ] );
+
+		self::assertSame( [ 101, 102, 103 ], $ids );
+	}
+
+	/**
+	 * Missing $wpdb on revision_ids_for_parents returns an empty list.
+	 */
+	public function test_revision_ids_for_parents_returns_empty_without_wpdb(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		self::assertSame( [], ( new RevisionRepository() )->revision_ids_for_parents( [ 1 ] ) );
+	}
+}

--- a/tests/Unit/Revisions/RevisionRepositoryTest.php
+++ b/tests/Unit/Revisions/RevisionRepositoryTest.php
@@ -16,7 +16,7 @@ use stdClass;
 final class RevisionRepositoryTest extends TestCase {
 
 	/**
-	 * Install a tiny $wpdb double.
+	 * Installs a tiny $wpdb double.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -25,7 +25,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * Remove the $wpdb double.
+	 * Removes the $wpdb double.
 	 */
 	protected function tearDown(): void {
 		unset( $GLOBALS['wpdb'] );

--- a/tests/Unit/Revisions/RevisionRepositoryTest.php
+++ b/tests/Unit/Revisions/RevisionRepositoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
- * Unit tests for RevisionRepository. We stub a tiny $wpdb double so the
+ * Covers RevisionRepository with unit tests. Stubs a tiny $wpdb double so the
  * SQL-execution paths are covered without a real DB.
  */
 final class RevisionRepositoryTest extends TestCase {
@@ -33,7 +33,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The paginated helper returns an empty array when $wpdb is not initialized.
+	 * Asserts the paginated helper returns an empty array when $wpdb is not initialized.
 	 */
 	public function test_paginated_returns_empty_without_wpdb(): void {
 		unset( $GLOBALS['wpdb'] );
@@ -42,7 +42,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The paginated helper maps $wpdb->get_results output into the overview row shape.
+	 * Asserts the paginated helper maps $wpdb->get_results output into the overview row shape.
 	 */
 	public function test_paginated_maps_db_rows_to_overview_shape(): void {
 		// phpcs:ignore SlevomatCodingStandard.PHP.ForbiddenClasses.ForbiddenClass
@@ -68,7 +68,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The paginated helper clamps per_page into a safe range.
+	 * Asserts the paginated helper clamps per_page into a safe range.
 	 */
 	public function test_paginated_clamps_per_page(): void {
 		$GLOBALS['wpdb']->next_results = [];
@@ -78,7 +78,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The total_parents helper returns 0 when $wpdb is not available.
+	 * Asserts the total_parents helper returns 0 when $wpdb is not available.
 	 */
 	public function test_total_parents_returns_zero_without_wpdb(): void {
 		unset( $GLOBALS['wpdb'] );
@@ -87,7 +87,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The total_parents helper returns the DB count as int.
+	 * Asserts the total_parents helper returns the DB count as int.
 	 */
 	public function test_total_parents_returns_db_count(): void {
 		$GLOBALS['wpdb']->next_var = 17;
@@ -96,14 +96,14 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * The revision_ids_for_parents helper short-circuits on empty input.
+	 * Asserts the revision_ids_for_parents helper short-circuits on empty input.
 	 */
 	public function test_revision_ids_for_parents_returns_empty_for_empty_input(): void {
 		self::assertSame( [], ( new RevisionRepository() )->revision_ids_for_parents( [] ) );
 	}
 
 	/**
-	 * The revision_ids_for_parents helper returns an int list from $wpdb->get_col.
+	 * Asserts the revision_ids_for_parents helper returns an int list from $wpdb->get_col.
 	 */
 	public function test_revision_ids_for_parents_casts_db_values_to_int(): void {
 		$GLOBALS['wpdb']->next_col = [ '101', '102', 103 ];
@@ -114,7 +114,7 @@ final class RevisionRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * Missing $wpdb on revision_ids_for_parents returns an empty list.
+	 * Asserts a missing $wpdb on revision_ids_for_parents returns an empty list.
 	 */
 	public function test_revision_ids_for_parents_returns_empty_without_wpdb(): void {
 		unset( $GLOBALS['wpdb'] );

--- a/tests/Unit/Revisions/TaxonomyRegistrarTest.php
+++ b/tests/Unit/Revisions/TaxonomyRegistrarTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\AdvancedRevisions\Tests\Unit\Revisions;
+
+use Apermo\AdvancedRevisions\Revisions\TaxonomyRegistrar;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for TaxonomyRegistrar — focus on hook wiring and register_taxonomy
+ * args. Full registration semantics are exercised by integration tests.
+ */
+final class TaxonomyRegistrarTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Registering wires both taxonomy and meta callbacks on init.
+	 */
+	public function test_register_hooks_init_callbacks(): void {
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'init', [ TaxonomyRegistrar::class, 'register_taxonomy' ] );
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'init', [ TaxonomyRegistrar::class, 'register_meta' ] );
+
+		TaxonomyRegistrar::register();
+	}
+
+	/**
+	 * The taxonomy is registered against the revision post type with the expected shape.
+	 */
+	public function test_register_taxonomy_uses_revision_post_type(): void {
+		$captured = [];
+		Functions\when( 'register_taxonomy' )->alias(
+			static function ( string $taxonomy, $object_type, array $args ) use ( &$captured ): void {
+				$captured = [
+					'taxonomy' => $taxonomy,
+					'object'   => $object_type,
+					'args'     => $args,
+				];
+			},
+		);
+
+		TaxonomyRegistrar::register_taxonomy();
+
+		self::assertSame( 'revision_tag', $captured['taxonomy'] );
+		self::assertSame( 'revision', $captured['object'] );
+		self::assertFalse( $captured['args']['public'] );
+		self::assertTrue( $captured['args']['show_in_rest'] );
+		self::assertTrue( $captured['args']['show_ui'] );
+		self::assertFalse( $captured['args']['hierarchical'] );
+	}
+
+	/**
+	 * Meta registration covers both the protected flag and the note key.
+	 */
+	public function test_register_meta_registers_protected_flag_and_note(): void {
+		$term_meta = [];
+		$post_meta = [];
+		Functions\when( 'register_term_meta' )->alias(
+			static function ( string $taxonomy, string $key, array $args ) use ( &$term_meta ): void {
+				$term_meta[] = [
+					'taxonomy' => $taxonomy,
+					'key'      => $key,
+					'args'     => $args,
+				];
+			},
+		);
+		Functions\when( 'register_post_meta' )->alias(
+			static function ( string $post_type, string $key, array $args ) use ( &$post_meta ): void {
+				$post_meta[] = [
+					'post_type' => $post_type,
+					'key'       => $key,
+					'args'      => $args,
+				];
+			},
+		);
+
+		TaxonomyRegistrar::register_meta();
+
+		self::assertCount( 1, $term_meta );
+		self::assertSame( 'revision_tag', $term_meta[0]['taxonomy'] );
+		self::assertSame( 'protected', $term_meta[0]['key'] );
+
+		self::assertCount( 1, $post_meta );
+		self::assertSame( 'revision', $post_meta[0]['post_type'] );
+		self::assertSame( '_advanced_revisions_note', $post_meta[0]['key'] );
+	}
+}

--- a/tests/Unit/Revisions/TaxonomyRegistrarTest.php
+++ b/tests/Unit/Revisions/TaxonomyRegistrarTest.php
@@ -72,11 +72,10 @@ final class TaxonomyRegistrarTest extends TestCase {
 	}
 
 	/**
-	 * Asserts meta registration covers both the protected flag and the note key.
+	 * Asserts meta registration covers the protected flag term meta.
 	 */
-	public function test_register_meta_registers_protected_flag_and_note(): void {
+	public function test_register_meta_registers_protected_flag(): void {
 		$term_meta = [];
-		$post_meta = [];
 		Functions\when( 'register_term_meta' )->alias(
 			static function ( string $taxonomy, string $key, array $args ) use ( &$term_meta ): void {
 				$term_meta[] = [
@@ -86,24 +85,11 @@ final class TaxonomyRegistrarTest extends TestCase {
 				];
 			},
 		);
-		Functions\when( 'register_post_meta' )->alias(
-			static function ( string $post_type, string $key, array $args ) use ( &$post_meta ): void {
-				$post_meta[] = [
-					'post_type' => $post_type,
-					'key'       => $key,
-					'args'      => $args,
-				];
-			},
-		);
 
 		TaxonomyRegistrar::register_meta();
 
 		self::assertCount( 1, $term_meta );
 		self::assertSame( 'revision_tag', $term_meta[0]['taxonomy'] );
 		self::assertSame( 'protected', $term_meta[0]['key'] );
-
-		self::assertCount( 1, $post_meta );
-		self::assertSame( 'revision', $post_meta[0]['post_type'] );
-		self::assertSame( '_advanced_revisions_note', $post_meta[0]['key'] );
 	}
 }

--- a/tests/Unit/Revisions/TaxonomyRegistrarTest.php
+++ b/tests/Unit/Revisions/TaxonomyRegistrarTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class TaxonomyRegistrarTest extends TestCase {
 
 	/**
-	 * Set up Brain Monkey.
+	 * Sets up Brain Monkey.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -25,7 +25,7 @@ final class TaxonomyRegistrarTest extends TestCase {
 	}
 
 	/**
-	 * Tear down Brain Monkey.
+	 * Tears down Brain Monkey.
 	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();

--- a/tests/Unit/Revisions/TaxonomyRegistrarTest.php
+++ b/tests/Unit/Revisions/TaxonomyRegistrarTest.php
@@ -33,7 +33,7 @@ final class TaxonomyRegistrarTest extends TestCase {
 	}
 
 	/**
-	 * Registering wires both taxonomy and meta callbacks on init.
+	 * Verifies register() wires both taxonomy and meta callbacks on init.
 	 */
 	public function test_register_hooks_init_callbacks(): void {
 		Functions\expect( 'add_action' )
@@ -47,7 +47,7 @@ final class TaxonomyRegistrarTest extends TestCase {
 	}
 
 	/**
-	 * The taxonomy is registered against the revision post type with the expected shape.
+	 * Asserts the taxonomy is registered against the revision post type with the expected shape.
 	 */
 	public function test_register_taxonomy_uses_revision_post_type(): void {
 		$captured = [];
@@ -72,7 +72,7 @@ final class TaxonomyRegistrarTest extends TestCase {
 	}
 
 	/**
-	 * Meta registration covers both the protected flag and the note key.
+	 * Asserts meta registration covers both the protected flag and the note key.
 	 */
 	public function test_register_meta_registers_protected_flag_and_note(): void {
 		$term_meta = [];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,7 +31,7 @@ if ( $wp_tests_dir !== false && is_dir( $wp_tests_dir ) ) {
 }
 
 /**
- * Load the plugin or theme under test.
+ * Loads the plugin or theme under test.
  *
  * @return void
  */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Unit-test stubs for WP classes used by the code under test. Only declared
+// when WP itself is not loaded (integration tests provide the real classes).
+if ( ! class_exists( 'WP_Post' ) ) {
+	require_once __DIR__ . '/wp-class-stubs.php';
+}
+
 $wp_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( $wp_tests_dir === false ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-// Unit-test stubs for WP classes used by the code under test. Only declared
-// when WP itself is not loaded (integration tests provide the real classes).
-if ( ! class_exists( 'WP_Post' ) ) {
-	require_once __DIR__ . '/wp-class-stubs.php';
-}
-
 $wp_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( $wp_tests_dir === false ) {
@@ -29,6 +23,11 @@ if ( $wp_tests_dir !== false && is_dir( $wp_tests_dir ) ) {
 	tests_add_filter( 'muplugins_loaded', 'advanced_revisions_tests_load_project' );
 
 	require_once $wp_tests_dir . '/includes/bootstrap.php';
+} else {
+	// No WordPress test suite available — unit tests only. Load minimal stubs
+	// for the WP classes our code-under-test references by type so Brain Monkey
+	// tests can run without a real WP bootstrap.
+	require_once __DIR__ . '/wp-class-stubs.php';
 }
 
 /**

--- a/tests/wp-class-stubs.php
+++ b/tests/wp-class-stubs.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Minimal stubs for WP classes used by code under unit test. Only loaded
+ * when WordPress itself is not available (i.e. outside integration tests).
+ *
+ * @package Advanced_Revisions_Tests
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable WordPress.NamingConventions.ValidClassName.InvalidClassName -- intentional: match core WP class names.
+// phpcs:disable Squiz.Commenting.ClassComment.Missing -- stubs are private test scaffolding.
+// phpcs:disable Apermo.NamingConventions.MinimumVariableNameLength.TooShort
+
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+
+		public int $ID = 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+		public string $post_title = '';
+
+		public string $post_content = '';
+
+		public string $post_author = '0';
+
+		public string $post_type = '';
+
+		public string $post_status = '';
+
+		public int $post_parent = 0;
+
+		public string $post_date = '';
+
+		public string $post_date_gmt = '';
+
+		public string $post_name = '';
+
+		public string $post_excerpt = '';
+
+		public function __construct( mixed $post = null ) {
+			unset( $post );
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_User' ) ) {
+	class WP_User {
+
+		public int $ID = 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+		public string $user_login = '';
+	}
+}
+
+if ( ! class_exists( 'WP_Query' ) ) {
+	class WP_Query {
+
+		/** @var array<int, mixed> */
+		public array $posts = [];
+
+		/**
+		 * @param array<string, mixed> $args
+		 */
+		public function __construct( array $args = [] ) {
+			unset( $args );
+		}
+	}
+}


### PR DESCRIPTION
## Closes

Closes #1, closes #2, closes #3, closes #4, closes #10, closes #11, closes #13, closes #14, closes #15, closes #16, closes #17, closes #19, closes #20, closes #21

## Summary

Implements the v0.1.0 milestone (11 issues) plus three coding-standards cleanup items (#19, #20, #21) made obsolete by the `apermo/apermo-coding-standards` 2.8.0 / 2.9.0 bumps that landed on this branch.

Intentionally broken up into atomic commits — each commit maps to one concern and can be reviewed independently.

## Progress

| Commit            | Theme                                                                               |
| ----------------- | ----------------------------------------------------------------------------------- |
| `c34c7eb`         | #14 Dev fixtures plugin with test CPTs                                              |
| `7db3c3a`         | #15 WP-CLI seed dummy content                                                       |
| `58c00ee`         | #16 WP-CLI seed dummy revisions                                                     |
| `429a60a`         | #1 Per-type revision limit                                                          |
| `da0ff60`         | #4 Post list column                                                                 |
| `49da4fd`         | #13 Tagging + protection (foundation)                                               |
| `f9a79eb`         | #10 Dashboard widget                                                                |
| `b5031f8`         | #11 Per-post override                                                               |
| `badb260`         | #2 + #3 Admin overview + bulk revision deletion                                     |
| `ae50e58`         | #17 Test plan doc                                                                   |
| `ecd720f`         | CI + review-comment fixes (bootstrap stub ordering, PHPStan memory, compare_url, capability, ProtectionService, seeder determinism, …) |
| `6dfb140`         | +33 unit tests to clear the 80% Codecov threshold                                   |
| `ba6c523`         | perf: scope PostListColumn SQL to the current screen                                |
| `1dbd63d`         | perf: batch ProtectionService term queries                                          |
| `c67afcb`         | #19 + #20 + #21 Drop inline PHPCS ignores obsoleted by standards 2.8.0              |
| `9733ab7`+`2c58545` | Coding-standards bumps to ^2.8 then ^2.9                                          |
| `b266bb7`         | `total_parents()` paginator denominator alignment + `ONLY_FULL_GROUP_BY` portability |
| `103d9d8`         | Dashboard `compute()` excludes autosaves + portable GROUP BY                        |
| `d476c34`         | Dashboard i18n via `_n()` + `wp_kses()` (plural-correct, full sentences)            |
| `dbf5228`         | PostListColumn `compare_url()` batching — eliminates per-row N+1                    |
| `702d995`         | ProtectionService termmeta priming — completes the N+1 batching line                |
| `6b1ca62`         | Meta-cap refactor: `delete_others_posts` + filterable + per-parent `edit_post` + `exit()` after redirects + widened `auth_callback` |
| `a4c7801`         | Screen-reader labels for overview select-all and row checkboxes                     |
| `45530cd`         | `wp_loaded` priority so metabox registration picks up late-registered CPTs          |
| `e82989e`         | README + CHANGELOG refresh for release                                              |

## Test plan

- [x] PHPCS (apermo-coding-standards 2.9.0) clean across `src/` and `advanced-revisions-dev/`
- [x] PHPStan (level 6) clean
- [x] 122 unit tests, 1016 assertions — all passing
- [x] Integration suite: 8 jobs (PHP 8.2/8.4 × WP 6.4/latest × single/multisite) all pass
- [x] E2E (`wp-env`) passing
- [x] Codecov patch + project checks passing (≈82% line coverage on `src/`)
- [x] `git archive HEAD | tar t` confirms `advanced-revisions-dev/` is NOT in the distribution

## Scope decisions worth flagging

- **#13 tagging** ships the foundation (taxonomy + term meta + `ProtectionService`). Sidebar panel + retroactive-tag metabox UI are deferred.
- **#2 + #3** combined — overview without bulk delete is half-baked. Uses a plain HTML table (not `WP_List_Table`) to keep it unit-testable. `WP_List_Table` upgrade is a follow-up.
- **Integration + E2E coverage matrix** rows in `docs/testing.md` are marked `—` (intentionally not covered at this layer) for v0.1.0. Infrastructure is in place; per-feature integration/E2E tests land as follow-ups.

## Review pointers

- Code review: click the **Commits** tab and walk top-to-bottom. Each commit stands on its own.
- Foundational commits (#14, #15, #16, #17) set up dev tooling; no production plugin behavior.
- Feature commits add one user-facing capability each.
- Trailing commits are the code-review response round: correctness fixes, perf batching, portability hardening, a11y labels, doc refresh.
